### PR TITLE
Add support for respondSingle and setting prefetchCount for AMQP async

### DIFF
--- a/src/main/java/conduit/amqp/AMQPAsyncListenProperties.java
+++ b/src/main/java/conduit/amqp/AMQPAsyncListenProperties.java
@@ -8,6 +8,7 @@ public class AMQPAsyncListenProperties implements TransportListenProperties {
     private String exchange;
     private String queue;
     private int threshold;
+    private int prefetchCount;
 
     public AMQPAsyncListenProperties(
             AMQPAsyncConsumerCallback callback
@@ -23,10 +24,21 @@ public class AMQPAsyncListenProperties implements TransportListenProperties {
           , String queue
           , int threshold
     ) {
+        this(callback, exchange, queue, threshold, 0);
+    }
+
+    public AMQPAsyncListenProperties(
+            AMQPAsyncConsumerCallback callback
+          , String exchange
+          , String queue
+          , int threshold
+          , int prefetchCount
+    ) {
         this.callback = callback;
         this.exchange = exchange;
         this.queue = queue;
         this.threshold = threshold;
+        this.prefetchCount = prefetchCount;
     }
 
     public AMQPAsyncConsumerCallback getCallback() {
@@ -43,5 +55,9 @@ public class AMQPAsyncListenProperties implements TransportListenProperties {
 
     public int getThreshold() {
         return threshold;
+    }
+
+    public int getPrefetchCount() {
+        return prefetchCount;
     }
 }

--- a/src/main/java/conduit/amqp/AMQPAsyncTransport.java
+++ b/src/main/java/conduit/amqp/AMQPAsyncTransport.java
@@ -21,7 +21,7 @@ public class AMQPAsyncTransport extends AMQPTransport {
               , listenProperties.getThreshold()
         );
 
-        getChannel().basicQos(0);
+        getChannel().basicQos(listenProperties.getPrefetchCount());
         getChannel().basicConsume(listenProperties.getQueue(), noAutoAck, consumer);
     }
 }

--- a/src/main/java/conduit/amqp/AsyncResponse.java
+++ b/src/main/java/conduit/amqp/AsyncResponse.java
@@ -8,4 +8,9 @@ public interface AsyncResponse {
      * Responds to all previously unacknowledged messages, up to and including the given message
      */
     public void respondMultiple(AMQPMessageBundle messageBundle, Action action);
+
+    /**
+     * Responds to a single unacknowledged message
+     */
+    public void respondSingle(AMQPMessageBundle messageBundle, Action action);
 }

--- a/src/main/java/conduit/amqp/builder/AMQPAsyncConsumerBuilder.java
+++ b/src/main/java/conduit/amqp/builder/AMQPAsyncConsumerBuilder.java
@@ -10,6 +10,7 @@ public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTrans
                                                                 , AMQPAsyncListenProperties
                                                                 , AMQPAsyncConsumerBuilder> {
     private AMQPAsyncConsumerCallback callback;
+    private int prefetchCount = 0;
 
     public static AMQPAsyncConsumerBuilder builder() {
         return new AMQPAsyncConsumerBuilder();
@@ -30,7 +31,7 @@ public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTrans
 
     @Override
     protected AMQPAsyncListenProperties buildListenProperties() {
-        return new AMQPAsyncListenProperties(callback, getExchange(), getQueue());
+        return new AMQPAsyncListenProperties(callback, getExchange(), getQueue(), getRetryThreshold(), prefetchCount);
     }
 
     @Override
@@ -38,5 +39,10 @@ public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTrans
                                                  , AMQPConnectionProperties connectionProperties
                                                  , AMQPAsyncListenProperties listenProperties) {
         return new AMQPListenContext(transport, connectionProperties, listenProperties);
+    }
+
+    public AMQPAsyncConsumerBuilder prefetchCount(int prefetchCount) {
+        this.prefetchCount = prefetchCount;
+        return this;
     }
 }

--- a/src/main/java/conduit/amqp/consumer/AMQPAsyncQueueConsumer.java
+++ b/src/main/java/conduit/amqp/consumer/AMQPAsyncQueueConsumer.java
@@ -12,13 +12,14 @@ import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.Queue;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 public class AMQPAsyncQueueConsumer extends AMQPQueueConsumer implements AsyncResponse {
     private static final Logger log = Logger.getLogger(AMQPQueueConsumer.class);
     private final AMQPAsyncConsumerCallback callback;
-    private final Queue<AMQPMessageBundle> unacknowledgedMessages = new LinkedList<AMQPMessageBundle>();
+    private final Map<Long, AMQPMessageBundle> unacknowledgedMessages = new LinkedHashMap<Long, AMQPMessageBundle>();
 
     public AMQPAsyncQueueConsumer(Channel channel, AMQPAsyncConsumerCallback callback, int threshold) {
         super(channel, null, threshold, "");
@@ -41,7 +42,7 @@ public class AMQPAsyncQueueConsumer extends AMQPQueueConsumer implements AsyncRe
         );
 
         try {
-            unacknowledgedMessages.offer(messageBundle);
+            unacknowledgedMessages.put(messageBundle.getEnvelope().getDeliveryTag(), messageBundle);
             callback.handle(messageBundle, this);
         } catch (RuntimeException e) {
             //! Blanket exception handler for notifying, via the log, that the user-supplied
@@ -52,40 +53,91 @@ public class AMQPAsyncQueueConsumer extends AMQPQueueConsumer implements AsyncRe
         }
     }
 
-    private void trimUnacknowlegedMessages(Long deliveryTag) {
-        Iterator<AMQPMessageBundle> messages = unacknowledgedMessages.iterator();
+    protected void respond(AMQPMessageBundle messageBundle, Action action, boolean multiple) {
+        //! We can't issue any blocking amqp calls in the context of this method, otherwise
+        //  channel's internal thread(s) will deadlock. Both, basicAck and basicReject are
+        //  asynchronous.
+        Envelope envelope = messageBundle.getEnvelope();
+        Long deliveryTag = envelope.getDeliveryTag();
+        byte[] body = messageBundle.getBody();
+        AMQP.BasicProperties properties = messageBundle.getBasicProperties();
+
+        try {
+            switch (action) {
+                case Acknowledge:
+                    ack(deliveryTag, multiple);
+                    break;
+
+                case RejectAndDiscard:
+                    log.warn("Discarding message, body = " + new String(body));
+                    //! Let the broker know we rejected this message. Then publish this bad boy onto
+                    //  the poison queue. Don't bother confirming for two reasons; we don't care, and
+                    //  we can't issue blocking calls here.
+                    publishToPoisonQueue(envelope, properties, body, multiple);
+                    reject(deliveryTag, multiple);
+                    break;
+
+                case RejectAndRequeue:
+                    log.warn("Received an unknown message, body = " + new String(body));
+                    log.warn("\tAdjusting headers for retry.");
+
+                    if (!retry(envelope, properties, body, multiple)) {
+                        publishToPoisonQueue(envelope, properties, body, multiple);
+                    }
+                    reject(deliveryTag, multiple);
+                    break;
+            }
+        } catch (Exception e) {
+            callback.notifyOfActionFailure(e);
+        }
+    }
+
+    private void removeUnacknowledgedMessages(Long deliveryTag, boolean multiple) {
+        if (!multiple) {
+            unacknowledgedMessages.remove(deliveryTag);
+            return;
+        }
+
+        Iterator<Entry<Long, AMQPMessageBundle>> messages = unacknowledgedMessages.entrySet().iterator();
 
         while (messages.hasNext()) {
-            AMQPMessageBundle next = messages.next();
+            Entry<Long, AMQPMessageBundle> next = messages.next();
 
-            if (next.getEnvelope().getDeliveryTag() > deliveryTag) {
+            if (next.getKey() > deliveryTag) {
                 break;
             }
             messages.remove();
         }
     }
 
-    @Override
-    protected void ack(Long deliveryTag) throws IOException {
-        trimUnacknowlegedMessages(deliveryTag);
-        channel.basicAck(deliveryTag, true);
+    private void ack(Long deliveryTag, boolean multiple) throws IOException {
+        removeUnacknowledgedMessages(deliveryTag, multiple);
+        channel.basicAck(deliveryTag, multiple);
     }
 
-    @Override
-    protected void reject(long deliveryTag) throws IOException {
-        trimUnacknowlegedMessages(deliveryTag);
-        channel.basicNack(deliveryTag, true, false);
+    private void reject(long deliveryTag, boolean multiple) throws IOException {
+        removeUnacknowledgedMessages(deliveryTag, multiple);
+        if (multiple) {
+            channel.basicNack(deliveryTag, true, false);
+        } else {
+            channel.basicReject(deliveryTag, false);
+        }
     }
 
     /**
      * Send all unacknowledged messages to poison queue, up-to and including this one
      * @throws IOException
      */
-    @Override
-    protected void publishToPoisonQueue(Envelope envelope
-                                      , AMQP.BasicProperties properties
-                                      , byte[] body) throws IOException {
-        Iterator<AMQPMessageBundle> messages = unacknowledgedMessages.iterator();
+    private void publishToPoisonQueue(Envelope envelope
+                                    , AMQP.BasicProperties properties
+                                    , byte[] body
+                                    , boolean multiple) throws IOException {
+        if (!multiple) {
+            super.publishToPoisonQueue(envelope, properties, body);
+            return;
+        }
+
+        Iterator<AMQPMessageBundle> messages = unacknowledgedMessages.values().iterator();
         long deliveryTag = envelope.getDeliveryTag();
 
         while (messages.hasNext()) {
@@ -103,10 +155,19 @@ public class AMQPAsyncQueueConsumer extends AMQPQueueConsumer implements AsyncRe
      * Retry all previously unacknowledged messages, up-to and including the one given
      * @throws IOException
      */
-    @Override
-    protected boolean retry(Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
-        Iterator<AMQPMessageBundle> messages = unacknowledgedMessages.iterator();
+    private boolean retry(Envelope envelope, AMQP.BasicProperties properties, byte[] body, boolean multiple)
+            throws IOException {
         boolean retry = true;
+
+        if (!multiple) {
+            retry = super.retry(envelope, properties, body);
+            if (retry) {
+                unacknowledgedMessages.remove(envelope.getDeliveryTag());
+            }
+            return retry;
+        }
+
+        Iterator<AMQPMessageBundle> messages = unacknowledgedMessages.values().iterator();
         long deliveryTag = envelope.getDeliveryTag();
 
         while (messages.hasNext()) {
@@ -130,6 +191,11 @@ public class AMQPAsyncQueueConsumer extends AMQPQueueConsumer implements AsyncRe
 
     @Override
     public void respondMultiple(AMQPMessageBundle messageBundle, Action action) {
-        respond(messageBundle, action);
+        respond(messageBundle, action, true);
+    }
+
+    @Override
+    public void respondSingle(AMQPMessageBundle messageBundle, Action action) {
+        respond(messageBundle, action, false);
     }
 }

--- a/src/main/java/conduit/amqp/consumer/AMQPQueueConsumer.java
+++ b/src/main/java/conduit/amqp/consumer/AMQPQueueConsumer.java
@@ -59,7 +59,7 @@ public class AMQPQueueConsumer extends DefaultConsumer {
         respond(messageBundle, action);
     }
 
-    protected void respond(AMQPMessageBundle messageBundle, Action action) {
+    private void respond(AMQPMessageBundle messageBundle, Action action) {
         //! We can't issue any blocking amqp calls in the context of this method, otherwise
         //  channel's internal thread(s) will deadlock. Both, basicAck and basicReject are
         //  asynchronous.
@@ -98,11 +98,11 @@ public class AMQPQueueConsumer extends DefaultConsumer {
         }
     }
 
-    protected void ack(Long deliveryTag) throws IOException {
+    private void ack(Long deliveryTag) throws IOException {
         channel.basicAck(deliveryTag, false);
     }
 
-    protected void reject(long deliveryTag) throws IOException {
+    private void reject(long deliveryTag) throws IOException {
         channel.basicReject(deliveryTag, false);
     }
 


### PR DESCRIPTION
Some explanation on how respondMultiple vs respondSingle works:

conduit accumulates messages that have not been responded to in a LinkedHashMap, in order to preserve order.  When you call respondMultiple with a message, there's an optimization in AMQP where you can ack or reject (nack) to multiple messages, up to and including a given message (via it's delivery tag, which is the key for the LinkedHashMap and always necessarily increases).  If you call respondSingle now, it will simple snipe a specific message and remove it from the map and call ack/reject for singular message rather than multiple.  As a result, the order of messages is always maintained, allowing you to mix respondSingle and respondMultiple
