### PR TITLE
Enabling the confirm-select mode, which actually makes the waitForConfir...

### DIFF
--- a/src/main/java/conduit/amqp/AMQPTransport.java
+++ b/src/main/java/conduit/amqp/AMQPTransport.java
@@ -95,6 +95,8 @@ public class AMQPTransport extends Transport {
         AMQPPublishProperties publishProperties = (AMQPPublishProperties)properties;
         AMQPMessageBundle messageBundle = (AMQPMessageBundle)bundle;
 
+        channel.confirmSelect();
+
         channel.basicPublish(
                 publishProperties.getExchange()
               , publishProperties.getRoutingKey()

--- a/src/test/java/publisher/PublisherTest.java
+++ b/src/test/java/publisher/PublisherTest.java
@@ -135,6 +135,7 @@ public class PublisherTest {
 
         AMQPMockedTransportInternals mocked = mock();
 
+        PowerMock.expectPrivate(mocked.channelMock, "confirmSelect").andReturn(null);
         PowerMock.expectPrivate(mocked.channelMock, "waitForConfirms", anyLong()).andReturn(true);
         PowerMock.expectPrivate(
                 mocked.channelMock
@@ -173,6 +174,7 @@ public class PublisherTest {
     public void testAMQPPublishDeepNegative() throws Exception {
         AMQPMockedTransportInternals mocked = mock();
 
+        PowerMock.expectPrivate(mocked.channelMock, "confirmSelect").andReturn(null);
         PowerMock.expectPrivate(mocked.channelMock, "waitForConfirms", anyLong()).andReturn(false);
         PowerMock.expectPrivate(
                 mocked.channelMock
@@ -219,6 +221,7 @@ public class PublisherTest {
         final BooleanWrapper txSelectCalled = new BooleanWrapper();
         final BooleanWrapper txCommitCalled = new BooleanWrapper();
 
+        PowerMock.expectPrivate(mocked.channelMock, "confirmSelect").andReturn(null).anyTimes();
         PowerMock.expectPrivate(mocked.channelMock, "waitForConfirms", anyLong()).andReturn(true).anyTimes();
         PowerMock.expectPrivate(mocked.channelMock, "txSelect").andAnswer(new IAnswer<Object>() {
                 @Override
@@ -283,6 +286,7 @@ public class PublisherTest {
         final BooleanWrapper txSelectCalled = new BooleanWrapper();
         final BooleanWrapper txRollbackCalled = new BooleanWrapper();
 
+        PowerMock.expectPrivate(mocked.channelMock, "confirmSelect").andReturn(null);
         PowerMock.expectPrivate(mocked.channelMock, "waitForConfirms", anyLong()).andReturn(false).anyTimes();
         PowerMock.expectPrivate(mocked.channelMock, "txSelect").andAnswer(new IAnswer<Object>() {
                 @Override


### PR DESCRIPTION
...ms work. waitForConfirms will now correctly return whether all messages have been acked by the broker.
