### PR TITLE
Adding ability to disable use of the poison queue. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/*
 *.iml
 target/*
+.classpath
+.project
+.settings/

--- a/src/main/java/conduit/amqp/AMQPAsyncListenProperties.java
+++ b/src/main/java/conduit/amqp/AMQPAsyncListenProperties.java
@@ -9,6 +9,7 @@ public class AMQPAsyncListenProperties implements TransportListenProperties {
     private String queue;
     private int threshold;
     private int prefetchCount;
+    private boolean poisonQueueEnabled;
 
     public AMQPAsyncListenProperties(
             AMQPAsyncConsumerCallback callback
@@ -26,7 +27,7 @@ public class AMQPAsyncListenProperties implements TransportListenProperties {
     ) {
         this(callback, exchange, queue, threshold, 0);
     }
-
+    
     public AMQPAsyncListenProperties(
             AMQPAsyncConsumerCallback callback
           , String exchange
@@ -34,11 +35,23 @@ public class AMQPAsyncListenProperties implements TransportListenProperties {
           , int threshold
           , int prefetchCount
     ) {
+        this(callback, exchange, queue, threshold, prefetchCount, true);
+    }
+
+    public AMQPAsyncListenProperties(
+            AMQPAsyncConsumerCallback callback
+          , String exchange
+          , String queue
+          , int threshold
+          , int prefetchCount
+          , boolean poisonQueueEnabled
+    ) {
         this.callback = callback;
         this.exchange = exchange;
         this.queue = queue;
         this.threshold = threshold;
         this.prefetchCount = prefetchCount;
+        this.poisonQueueEnabled = poisonQueueEnabled;
     }
 
     public AMQPAsyncConsumerCallback getCallback() {
@@ -59,5 +72,9 @@ public class AMQPAsyncListenProperties implements TransportListenProperties {
 
     public int getPrefetchCount() {
         return prefetchCount;
+    }
+    
+    public boolean isPoisonQueueEnabled() {
+    	return poisonQueueEnabled;
     }
 }

--- a/src/main/java/conduit/amqp/AMQPAsyncTransport.java
+++ b/src/main/java/conduit/amqp/AMQPAsyncTransport.java
@@ -19,6 +19,7 @@ public class AMQPAsyncTransport extends AMQPTransport {
                 getChannel()
               , listenProperties.getCallback()
               , listenProperties.getThreshold()
+              , listenProperties.isPoisonQueueEnabled()
         );
 
         getChannel().basicQos(listenProperties.getPrefetchCount());

--- a/src/main/java/conduit/amqp/AMQPListenProperties.java
+++ b/src/main/java/conduit/amqp/AMQPListenProperties.java
@@ -14,6 +14,7 @@ public class AMQPListenProperties implements TransportListenProperties {
     private int threshold;
     private boolean purgeOnConnect;
     private String poisonPrefix;
+    private boolean poisonQueueEnabled;
 
     public static class AMQPListenPropertiesBuilder{
         private AMQPConsumerCallback callback;
@@ -22,6 +23,7 @@ public class AMQPListenProperties implements TransportListenProperties {
         private int threshold;
         private boolean purgeOnConnect;
         private String poisonPrefix;
+        private boolean poisonQueueEnabled = true;
 
         public AMQPListenPropertiesBuilder(AMQPConsumerCallback callback, String exchange, String queue){
             this.callback = callback;
@@ -32,6 +34,11 @@ public class AMQPListenProperties implements TransportListenProperties {
         public AMQPListenPropertiesBuilder setPoisonPrefix(String poisonPrefix) {
             this.poisonPrefix = poisonPrefix;
             return this;
+        }
+        
+        public AMQPListenPropertiesBuilder setPoisonQueueEnabled(boolean enabled) {
+        	this.poisonQueueEnabled = enabled;
+        	return this;
         }
 
         public AMQPListenPropertiesBuilder setThreshold(int threshold) {
@@ -51,7 +58,7 @@ public class AMQPListenProperties implements TransportListenProperties {
             if(poisonPrefix != null){
                 amqpListenProperties.poisonPrefix = poisonPrefix;
             }
-
+            amqpListenProperties.poisonQueueEnabled = poisonQueueEnabled;
             return amqpListenProperties;
         }
     }
@@ -70,11 +77,22 @@ public class AMQPListenProperties implements TransportListenProperties {
           , String queue
           , int threshold
     ) {
+        this(callback, exchange, queue, threshold, true);
+    }
+    
+    public AMQPListenProperties(
+            AMQPConsumerCallback callback
+          , String exchange
+          , String queue
+          , int threshold
+          , boolean poisonQueueEnabled
+    ) {
         this.callback = callback;
         this.exchange = exchange;
         this.queue = queue;
         this.threshold = threshold;
         this.poisonPrefix = "";
+        this.poisonQueueEnabled = poisonQueueEnabled;
     }
 
     public AMQPConsumerCallback getCallback() {
@@ -99,5 +117,9 @@ public class AMQPListenProperties implements TransportListenProperties {
 
     public String getPoisonPrefix() {
         return poisonPrefix;
+    }
+    
+    public boolean isPoisonQueueEnabled() {
+    	return poisonQueueEnabled;
     }
 }

--- a/src/main/java/conduit/amqp/AMQPTransport.java
+++ b/src/main/java/conduit/amqp/AMQPTransport.java
@@ -67,7 +67,8 @@ public class AMQPTransport extends Transport {
                 channel,
                 listenProperties.getCallback(),
                 listenProperties.getThreshold(),
-                listenProperties.getPoisonPrefix()
+                listenProperties.getPoisonPrefix(),
+                listenProperties.isPoisonQueueEnabled()
         );
 
 

--- a/src/main/java/conduit/amqp/builder/AMQPAsyncConsumerBuilder.java
+++ b/src/main/java/conduit/amqp/builder/AMQPAsyncConsumerBuilder.java
@@ -31,7 +31,7 @@ public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTrans
 
     @Override
     protected AMQPAsyncListenProperties buildListenProperties() {
-        return new AMQPAsyncListenProperties(callback, getExchange(), getQueue(), getRetryThreshold(), prefetchCount);
+        return new AMQPAsyncListenProperties(callback, getExchange(), getQueue(), getRetryThreshold(), prefetchCount, isPoisonQueueEnabled());
     }
 
     @Override

--- a/src/main/java/conduit/amqp/builder/AMQPConsumerBuilder.java
+++ b/src/main/java/conduit/amqp/builder/AMQPConsumerBuilder.java
@@ -23,6 +23,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     private int connectionTimeout = 0; //! 0 is infinite.
     private int heartbeatInterval = 60; //! In seconds.
     private int retryThreshold = 10;
+    private boolean poisonQueueEnabled = true;
 
     protected AMQPConsumerBuilder() {
     }
@@ -109,6 +110,15 @@ public abstract class AMQPConsumerBuilder<T extends Transport
         return retryThreshold;
     }
 
+    public R poisonQueueEnabled(boolean enabled) {
+    	this.poisonQueueEnabled = enabled;
+    	return builder();
+    }
+    
+    protected boolean isPoisonQueueEnabled() {
+    	return poisonQueueEnabled;
+    }
+    
     @Override
     protected void validate() {
         assertNotNull(exchange, "exchange");

--- a/src/main/java/conduit/amqp/builder/AMQPSyncConsumerBuilder.java
+++ b/src/main/java/conduit/amqp/builder/AMQPSyncConsumerBuilder.java
@@ -30,7 +30,7 @@ public class AMQPSyncConsumerBuilder extends AMQPConsumerBuilder<AMQPTransport
 
     @Override
     protected AMQPListenProperties buildListenProperties() {
-        return new AMQPListenProperties(callback, getExchange(), getQueue(), getRetryThreshold());
+        return new AMQPListenProperties(callback, getExchange(), getQueue(), getRetryThreshold(), isPoisonQueueEnabled());
     }
 
     @Override

--- a/src/main/java/conduit/amqp/consumer/AMQPAsyncQueueConsumer.java
+++ b/src/main/java/conduit/amqp/consumer/AMQPAsyncQueueConsumer.java
@@ -21,8 +21,8 @@ public class AMQPAsyncQueueConsumer extends AMQPQueueConsumer implements AsyncRe
     private final AMQPAsyncConsumerCallback callback;
     private final Map<Long, AMQPMessageBundle> unacknowledgedMessages = new LinkedHashMap<Long, AMQPMessageBundle>();
 
-    public AMQPAsyncQueueConsumer(Channel channel, AMQPAsyncConsumerCallback callback, int threshold) {
-        super(channel, null, threshold, "");
+    public AMQPAsyncQueueConsumer(Channel channel, AMQPAsyncConsumerCallback callback, int threshold, boolean poisonQueueEnabled) {
+        super(channel, null, threshold, "", poisonQueueEnabled);
         this.callback = callback;
     }
 

--- a/src/main/java/conduit/amqp/consumer/AMQPQueueConsumer.java
+++ b/src/main/java/conduit/amqp/consumer/AMQPQueueConsumer.java
@@ -21,13 +21,15 @@ public class AMQPQueueConsumer extends DefaultConsumer {
     private int threshold;
     protected final Channel channel;
     private String poisonPrefix;
+    private boolean poisonQueueEnabled;
 
-    public AMQPQueueConsumer(Channel channel, AMQPConsumerCallback callback, int threshold, String poisonPrefix) {
+    public AMQPQueueConsumer(Channel channel, AMQPConsumerCallback callback, int threshold, String poisonPrefix, boolean poisonQueueEnabled) {
         super(channel);
         this.callback = callback;
         this.threshold = threshold;
         this.channel = channel;
         this.poisonPrefix = poisonPrefix;
+        this.poisonQueueEnabled = poisonQueueEnabled;
     }
 
     @Override
@@ -148,6 +150,10 @@ public class AMQPQueueConsumer extends DefaultConsumer {
 
     protected void publishToPoisonQueue(Envelope envelope, AMQP.BasicProperties properties, byte[] body)
             throws IOException {
+    	if (!poisonQueueEnabled) {
+    		return;
+    	}
+    	
         channel.basicPublish(
                 envelope.getExchange()
               , envelope.getRoutingKey() + poisonPrefix + ".poison"


### PR DESCRIPTION
This will allow use of conduit consumers with a fanout exchange. Fixes #11
