### PR TITLE
INFRA-2453 ensureBasicConfig

### DIFF
--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
@@ -37,7 +37,7 @@ public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTrans
                 isDynamicQueueCreation(),
                 getPoisonPrefix(),
                 getDynamicQueueRoutingKey(),
-                isEnsureBasicConfig(),
+                isAutoCreateAndBind(),
                 getExchangeType(),
                 getRoutingKey());
     }

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
@@ -36,7 +36,10 @@ public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTrans
                 shouldPurgeOnConnect(),
                 isDynamicQueueCreation(),
                 getPoisonPrefix(),
-                getDynamicQueueRoutingKey());
+                getDynamicQueueRoutingKey(),
+                isEnsureBasicConfig(),
+                getExchangeType(),
+                getRoutingKey());
     }
 
     @Override

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncListenProperties.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncListenProperties.java
@@ -5,8 +5,8 @@ import io.rtr.conduit.amqp.AMQPAsyncConsumerCallback;
 public class AMQPAsyncListenProperties extends AMQPCommonListenProperties {
     private AMQPAsyncConsumerCallback callback;
 
-    AMQPAsyncListenProperties(AMQPAsyncConsumerCallback callback, String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean ensureBasicConfig, String exchangeType, String routingKey) {
-        super(exchange, queue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey, ensureBasicConfig, exchangeType, routingKey);
+    AMQPAsyncListenProperties(AMQPAsyncConsumerCallback callback, String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean autoCreateAndBind, String exchangeType, String routingKey) {
+        super(exchange, queue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey, autoCreateAndBind, exchangeType, routingKey);
         this.callback = callback;
     }
     public AMQPAsyncConsumerCallback getCallback() {

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncListenProperties.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncListenProperties.java
@@ -5,8 +5,8 @@ import io.rtr.conduit.amqp.AMQPAsyncConsumerCallback;
 public class AMQPAsyncListenProperties extends AMQPCommonListenProperties {
     private AMQPAsyncConsumerCallback callback;
 
-    AMQPAsyncListenProperties(AMQPAsyncConsumerCallback callback, String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey) {
-        super(exchange, queue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey);
+    AMQPAsyncListenProperties(AMQPAsyncConsumerCallback callback, String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean ensureBasicConfig, String exchangeType, String routingKey) {
+        super(exchange, queue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey, ensureBasicConfig, exchangeType, routingKey);
         this.callback = callback;
     }
     public AMQPAsyncConsumerCallback getCallback() {

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPCommonListenProperties.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPCommonListenProperties.java
@@ -13,11 +13,11 @@ public abstract class AMQPCommonListenProperties implements TransportListenPrope
     private String poisonPrefix;
     private String dynamicQueueRoutingKey;
     private String routingKey;
-    private boolean ensureBasicConfig;
+    private boolean autoCreateAndBind;
     private String exchangeType;
 
 
-    AMQPCommonListenProperties(String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean ensureBasicConfig, String exchangeType, String routingKey) {
+    AMQPCommonListenProperties(String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean autoCreateAndBind, String exchangeType, String routingKey) {
         this.exchange = exchange;
         this.queue = queue;
         this.threshold = threshold;
@@ -28,7 +28,7 @@ public abstract class AMQPCommonListenProperties implements TransportListenPrope
         this.poisonPrefix = poisonPrefix;
         this.dynamicQueueRoutingKey = dynamicQueueRoutingKey;
         this.routingKey = routingKey;
-        this.ensureBasicConfig = ensureBasicConfig;
+        this.autoCreateAndBind = autoCreateAndBind;
         this.exchangeType = exchangeType;
     }
 
@@ -76,7 +76,7 @@ public abstract class AMQPCommonListenProperties implements TransportListenPrope
         return exchangeType;
     }
 
-    public boolean isEnsureBasicConfig() {
-        return ensureBasicConfig;
+    public boolean isAutoCreateAndBind() {
+        return autoCreateAndBind;
     }
 }

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPCommonListenProperties.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPCommonListenProperties.java
@@ -12,8 +12,12 @@ public abstract class AMQPCommonListenProperties implements TransportListenPrope
     private boolean dynamicQueueCreation;
     private String poisonPrefix;
     private String dynamicQueueRoutingKey;
+    private String routingKey;
+    private boolean ensureBasicConfig;
+    private String exchangeType;
 
-    AMQPCommonListenProperties(String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey) {
+
+    AMQPCommonListenProperties(String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean ensureBasicConfig, String exchangeType, String routingKey) {
         this.exchange = exchange;
         this.queue = queue;
         this.threshold = threshold;
@@ -23,6 +27,9 @@ public abstract class AMQPCommonListenProperties implements TransportListenPrope
         this.dynamicQueueCreation = dynamicQueueCreation;
         this.poisonPrefix = poisonPrefix;
         this.dynamicQueueRoutingKey = dynamicQueueRoutingKey;
+        this.routingKey = routingKey;
+        this.ensureBasicConfig = ensureBasicConfig;
+        this.exchangeType = exchangeType;
     }
 
     public String getExchange() {
@@ -61,4 +68,15 @@ public abstract class AMQPCommonListenProperties implements TransportListenPrope
         return dynamicQueueRoutingKey;
     }
 
+    public String getRoutingKey() {
+        return routingKey;
+    }
+
+    public String getExchangeType() {
+        return exchangeType;
+    }
+
+    public boolean isEnsureBasicConfig() {
+        return ensureBasicConfig;
+    }
 }

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
@@ -158,7 +158,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
         this.exchange = exchange;
         this.queue = queue;
         this.exchangeType = exchangeType;
-        this.routingKey = routingKey;
+        this.routingKey = (routingKey == null) ? "" : routingKey;
         return builder();
     }
 

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
@@ -28,7 +28,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     private String poisonPrefix = "";
     private String dynamicQueueRoutingKey = "";
     private String routingKey = "";
-    private boolean ensureBasicConfig = false;
+    private boolean autoCreateAndBind = false;
     private ExchangeType exchangeType = ExchangeType.DIRECT;
 
     protected AMQPConsumerBuilder() {
@@ -142,7 +142,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     }
 
     /*
-    Ensures that the exchange and queue both exist and they are binded.
+    Auto create the exchange, queue and then bind them together.
 
     There are a few assumptions to keep this 'light' and compatible with typical usage:
      - Queues are durable
@@ -153,8 +153,8 @@ public abstract class AMQPConsumerBuilder<T extends Transport
      - No custom TTL
 
      */
-    public R ensureBasicConfig(String exchange, ExchangeType exchangeType, String queue, String routingKey) {
-        this.ensureBasicConfig = true;
+    public R autoCreateAndBind(String exchange, ExchangeType exchangeType, String queue, String routingKey) {
+        this.autoCreateAndBind = true;
         this.exchange = exchange;
         this.queue = queue;
         this.exchangeType = exchangeType;
@@ -162,8 +162,8 @@ public abstract class AMQPConsumerBuilder<T extends Transport
         return builder();
     }
 
-    public boolean isEnsureBasicConfig() {
-        return ensureBasicConfig;
+    public boolean isAutoCreateAndBind() {
+        return autoCreateAndBind;
     }
 
     public String getRoutingKey() {
@@ -201,8 +201,8 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     @Override
     protected void validate() {
         assertNotNull(exchange, "exchange");
-        if (dynamicQueueCreation && ensureBasicConfig) {
-            throw new IllegalArgumentException("Both dynamicQueueCreation and ensureBasicConfig are enabled.");
+        if (dynamicQueueCreation && autoCreateAndBind) {
+            throw new IllegalArgumentException("Both dynamicQueueCreation and autoCreateAndBind are enabled.");
         }
         if(!dynamicQueueCreation){
             assertNotNull(queue, "queue");
@@ -210,7 +210,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
         else{
             assertNotNull(dynamicQueueRoutingKey, "dynamicQueueRoutingKey");
         }
-        if (ensureBasicConfig) {
+        if (autoCreateAndBind) {
             assertNotNull(queue, "queue");
             assertNotNull(exchangeType, "exchangeType");
             assertNotNull(routingKey, "routingKey");

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPListenProperties.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPListenProperties.java
@@ -11,8 +11,8 @@ import io.rtr.conduit.amqp.transport.TransportListenProperties;
 public class AMQPListenProperties extends AMQPCommonListenProperties implements TransportListenProperties {
     private AMQPConsumerCallback callback;
 
-    AMQPListenProperties(AMQPConsumerCallback callback, String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean ensureBasicConfig, String exchangeType, String routingKey) {
-        super(exchange, queue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey, ensureBasicConfig, exchangeType, routingKey);
+    AMQPListenProperties(AMQPConsumerCallback callback, String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean autoCreateAndBind, String exchangeType, String routingKey) {
+        super(exchange, queue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey, autoCreateAndBind, exchangeType, routingKey);
         this.callback = callback;
     }
 

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPListenProperties.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPListenProperties.java
@@ -11,8 +11,8 @@ import io.rtr.conduit.amqp.transport.TransportListenProperties;
 public class AMQPListenProperties extends AMQPCommonListenProperties implements TransportListenProperties {
     private AMQPConsumerCallback callback;
 
-    AMQPListenProperties(AMQPConsumerCallback callback, String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey) {
-        super(exchange, queue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey);
+    AMQPListenProperties(AMQPConsumerCallback callback, String exchange, String queue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean ensureBasicConfig, String exchangeType, String routingKey) {
+        super(exchange, queue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey, ensureBasicConfig, exchangeType, routingKey);
         this.callback = callback;
     }
 

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
@@ -36,7 +36,10 @@ public class AMQPSyncConsumerBuilder extends AMQPConsumerBuilder<AMQPTransport
                 shouldPurgeOnConnect(),
                 isDynamicQueueCreation(),
                 getPoisonPrefix(),
-                getDynamicQueueRoutingKey());
+                getDynamicQueueRoutingKey(),
+                isEnsureBasicConfig(),
+                getExchangeType(),
+                getRoutingKey());
     }
 
     @Override

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
@@ -37,7 +37,7 @@ public class AMQPSyncConsumerBuilder extends AMQPConsumerBuilder<AMQPTransport
                 isDynamicQueueCreation(),
                 getPoisonPrefix(),
                 getDynamicQueueRoutingKey(),
-                isEnsureBasicConfig(),
+                isAutoCreateAndBind(),
                 getExchangeType(),
                 getRoutingKey());
     }

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
@@ -104,8 +104,8 @@ public class AMQPTransport extends AbstractAMQPTransport {
                     commonListenProperties.getDynamicQueueRoutingKey(),
                     commonListenProperties.isPoisonQueueEnabled());
             poisonPrefix = "." + queue;
-        } else if(commonListenProperties.isEnsureBasicConfig()) {
-            ensureBasicConfig(
+        } else if(commonListenProperties.isAutoCreateAndBind()) {
+            autoCreateAndBind(
                     commonListenProperties.getExchange(),
                     commonListenProperties.getExchangeType(),
                     commonListenProperties.getQueue(),
@@ -139,7 +139,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
         return queue;
     }
 
-    void ensureBasicConfig(String exchange, String exchangeType, String queue, String routingKey, boolean isPoisonQueueEnabled) throws IOException {
+    void autoCreateAndBind(String exchange, String exchangeType, String queue, String routingKey, boolean isPoisonQueueEnabled) throws IOException {
         // Creates durable non-autodeleted exchange and queue(s).
         channel.exchangeDeclare(exchange, exchangeType, true);
         channel.queueDeclare(queue, true, false, false, null);

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
@@ -104,6 +104,13 @@ public class AMQPTransport extends AbstractAMQPTransport {
                     commonListenProperties.getDynamicQueueRoutingKey(),
                     commonListenProperties.isPoisonQueueEnabled());
             poisonPrefix = "." + queue;
+        } else if(commonListenProperties.isEnsureBasicConfig()) {
+            ensureBasicConfig(
+                    commonListenProperties.getExchange(),
+                    commonListenProperties.getExchangeType(),
+                    commonListenProperties.getQueue(),
+                    commonListenProperties.getRoutingKey(),
+                    commonListenProperties.isPoisonQueueEnabled());
         }
 
         if(commonListenProperties.shouldPurgeOnConnect()){
@@ -130,6 +137,19 @@ public class AMQPTransport extends AbstractAMQPTransport {
             channel.queueBind(poisonQueue, exchange, routingKey + "." + queue + POISON);
         }
         return queue;
+    }
+
+    protected void ensureBasicConfig(String exchange, String exchangeType, String queue, String routingKey, boolean isPoisonQueueEnabled) throws IOException {
+        // Creates durable non-autodeleted exchange and queue(s).
+        channel.exchangeDeclare(exchange, exchangeType, true);
+        channel.queueDeclare(queue, true, false, false, null);
+        channel.queueBind(queue, exchange, routingKey);
+        if(isPoisonQueueEnabled){
+            String poisonQueue = queue + POISON;
+            channel.queueDeclare(poisonQueue, true, false, false, null);
+            channel.queueBind(poisonQueue, exchange, routingKey + POISON);
+        }
+
     }
 
     @Override

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
@@ -34,7 +34,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
     private ConnectionFactory factory = new ConnectionFactory();
     private Connection connection;
     private Channel channel;
-    private final static String POISON = ".poison";
+    final static String POISON = ".poison";
 
     AMQPTransport(String host, int port) {
         factory.setHost(host);
@@ -139,7 +139,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
         return queue;
     }
 
-    protected void ensureBasicConfig(String exchange, String exchangeType, String queue, String routingKey, boolean isPoisonQueueEnabled) throws IOException {
+    void ensureBasicConfig(String exchange, String exchangeType, String queue, String routingKey, boolean isPoisonQueueEnabled) throws IOException {
         // Creates durable non-autodeleted exchange and queue(s).
         channel.exchangeDeclare(exchange, exchangeType, true);
         channel.queueDeclare(queue, true, false, false, null);

--- a/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
+++ b/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
@@ -40,20 +40,23 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
-    public void testValidationBasicConfig(){
+    public void testValidationAutoCreateAndBind(){
         AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
                 .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, "queue", "routingKey");
         AMQPCommonListenProperties commonListenProperties = amqpAsyncConsumerBuilder.buildListenProperties();
 
-        assertEquals("Can not autoCreateAndBind and be dynamic", false, commonListenProperties.isDynamicQueueCreation());
+        // check that the properties got set correctly
         assertEquals("Queue should be: ", "queue", commonListenProperties.getQueue());
         assertEquals("Exchange should be: ", "exchange", commonListenProperties.getExchange());
         assertEquals("RoutingKey should be: ", "routingKey", commonListenProperties.getRoutingKey());
         assertEquals("ExchangeType should be: ", AMQPConsumerBuilder.ExchangeType.DIRECT.toString(), commonListenProperties.getExchangeType());
+
+        // Now check that the defaults validate.
+        amqpAsyncConsumerBuilder.validate();
     }
 
     @Test
-    public void testValidationBasicConfigWithNullRoutingKey(){
+    public void testValidationAutoCreateAndBindWithNullRoutingKey(){
         AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
                 .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, "queue", null);
 
@@ -64,14 +67,14 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testValidationBasicConfigWithNullQueue(){
+    public void testValidationAutoCreateAndBindWithNullQueue(){
         AMQPAsyncConsumerBuilder.builder()
                 .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, null, "routingKey")
                 .build();
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testValidationBasicConfigWithDynamic(){
+    public void testValidationAutoCreateAndBindWithDynamic(){
         AMQPAsyncConsumerBuilder.builder()
                 .dynamicQueueCreation(true)
                 .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, null, "routingKey")
@@ -79,7 +82,7 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testValidationBasicConfigWithPoisonFanout(){
+    public void testValidationAutoCreateAndBindWithPoisonFanout(){
         AMQPAsyncConsumerBuilder.builder()
                 .poisonQueueEnabled(true)
                 .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.FANOUT, null, "routingKey")

--- a/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
+++ b/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
@@ -42,10 +42,10 @@ public class AMQPAsyncConsumerBuilderTest {
     @Test
     public void testValidationBasicConfig(){
         AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
-                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, "queue", "routingKey");
+                .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, "queue", "routingKey");
         AMQPCommonListenProperties commonListenProperties = amqpAsyncConsumerBuilder.buildListenProperties();
 
-        assertEquals("Can not ensureBasicConfig and be dynamic", false, commonListenProperties.isDynamicQueueCreation());
+        assertEquals("Can not autoCreateAndBind and be dynamic", false, commonListenProperties.isDynamicQueueCreation());
         assertEquals("Queue should be: ", "queue", commonListenProperties.getQueue());
         assertEquals("Exchange should be: ", "exchange", commonListenProperties.getExchange());
         assertEquals("RoutingKey should be: ", "routingKey", commonListenProperties.getRoutingKey());
@@ -55,7 +55,7 @@ public class AMQPAsyncConsumerBuilderTest {
     @Test
     public void testValidationBasicConfigWithNullRoutingKey(){
         AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
-                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, "queue", null);
+                .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, "queue", null);
 
         AMQPCommonListenProperties commonListenProperties = amqpAsyncConsumerBuilder
                 .buildListenProperties();
@@ -66,7 +66,7 @@ public class AMQPAsyncConsumerBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void testValidationBasicConfigWithNullQueue(){
         AMQPAsyncConsumerBuilder.builder()
-                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, null, "routingKey")
+                .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, null, "routingKey")
                 .build();
     }
 
@@ -74,7 +74,7 @@ public class AMQPAsyncConsumerBuilderTest {
     public void testValidationBasicConfigWithDynamic(){
         AMQPAsyncConsumerBuilder.builder()
                 .dynamicQueueCreation(true)
-                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, null, "routingKey")
+                .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, null, "routingKey")
                 .build();
     }
 
@@ -82,7 +82,7 @@ public class AMQPAsyncConsumerBuilderTest {
     public void testValidationBasicConfigWithPoisonFanout(){
         AMQPAsyncConsumerBuilder.builder()
                 .poisonQueueEnabled(true)
-                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.FANOUT, null, "routingKey")
+                .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.FANOUT, null, "routingKey")
                 .build();
     }
 

--- a/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
+++ b/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
@@ -3,6 +3,7 @@ package io.rtr.conduit.amqp.impl;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class AMQPAsyncConsumerBuilderTest {
 
@@ -51,11 +52,15 @@ public class AMQPAsyncConsumerBuilderTest {
         assertEquals("ExchangeType should be: ", AMQPConsumerBuilder.ExchangeType.DIRECT.toString(), commonListenProperties.getExchangeType());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testValidationBasicConfigWithNullRoutingKey(){
-        AMQPAsyncConsumerBuilder.builder()
-                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, "queue", null)
-                .build();
+        AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
+                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, "queue", null);
+
+        AMQPCommonListenProperties commonListenProperties = amqpAsyncConsumerBuilder
+                .buildListenProperties();
+        assertNotNull(commonListenProperties.getRoutingKey());
+        assertEquals("", commonListenProperties.getRoutingKey());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
+++ b/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
@@ -39,6 +39,49 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
+    public void testValidationBasicConfig(){
+        AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
+                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, "queue", "routingKey");
+        AMQPCommonListenProperties commonListenProperties = amqpAsyncConsumerBuilder.buildListenProperties();
+
+        assertEquals("Can not ensureBasicConfig and be dynamic", false, commonListenProperties.isDynamicQueueCreation());
+        assertEquals("Queue should be: ", "queue", commonListenProperties.getQueue());
+        assertEquals("Exchange should be: ", "exchange", commonListenProperties.getExchange());
+        assertEquals("RoutingKey should be: ", "routingKey", commonListenProperties.getRoutingKey());
+        assertEquals("ExchangeType should be: ", AMQPConsumerBuilder.ExchangeType.DIRECT.toString(), commonListenProperties.getExchangeType());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidationBasicConfigWithNullRoutingKey(){
+        AMQPAsyncConsumerBuilder.builder()
+                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, "queue", null)
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidationBasicConfigWithNullQueue(){
+        AMQPAsyncConsumerBuilder.builder()
+                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, null, "routingKey")
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidationBasicConfigWithDynamic(){
+        AMQPAsyncConsumerBuilder.builder()
+                .dynamicQueueCreation(true)
+                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.DIRECT, null, "routingKey")
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidationBasicConfigWithPoisonFanout(){
+        AMQPAsyncConsumerBuilder.builder()
+                .poisonQueueEnabled(true)
+                .ensureBasicConfig("exchange", AMQPConsumerBuilder.ExchangeType.FANOUT, null, "routingKey")
+                .build();
+    }
+
+    @Test
     public void testDefaultDynamic(){
         AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
                 .exchange("exchange")

--- a/src/test/java/io/rtr/conduit/amqp/impl/AMQPTransportTest.java
+++ b/src/test/java/io/rtr/conduit/amqp/impl/AMQPTransportTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 public class AMQPTransportTest {
-    protected static final String POISON = ".poison";
     Channel channel;
     AMQPTransport amqpTransport;
     AMQPPublishProperties properties;
@@ -145,8 +144,8 @@ public class AMQPTransportTest {
         verify(channel, times(1)).exchangeDeclare(exchange, exchangeType.toString(), true);
         verify(channel, times(1)).queueDeclare(queue, true, false, false, null);
         verify(channel, times(1)).queueBind(queue, exchange, routingKey);
-        verify(channel, times(1)).queueDeclare(queue + POISON, true, false, false, null);
-        verify(channel, times(1)).queueBind(queue + POISON, exchange, routingKey + POISON);
+        verify(channel, times(1)).queueDeclare(queue + AMQPTransport.POISON, true, false, false, null);
+        verify(channel, times(1)).queueBind(queue + AMQPTransport.POISON, exchange, routingKey + AMQPTransport.POISON);
 
         verify(channel).basicConsume(eq(queue), eq(false), any(Consumer.class));
         verify(channel).basicQos(1);

--- a/src/test/java/io/rtr/conduit/amqp/impl/AMQPTransportTest.java
+++ b/src/test/java/io/rtr/conduit/amqp/impl/AMQPTransportTest.java
@@ -132,14 +132,14 @@ public class AMQPTransportTest {
 
         AMQPCommonListenProperties commonListenProperties = AMQPSyncConsumerBuilder.builder()
                 .callback(consumerCallback)
-                .ensureBasicConfig(exchange, exchangeType, queue, routingKey)
+                .autoCreateAndBind(exchange, exchangeType, queue, routingKey)
                 .poisonQueueEnabled(Boolean.TRUE)
                 .prefetchCount(1)
                 .buildListenProperties();
 
         amqpTransport.listenImpl(commonListenProperties);
         verify(amqpTransport).getConsumer(consumerCallback, commonListenProperties, "");
-        verify(amqpTransport).ensureBasicConfig(exchange, exchangeType.toString(), queue, routingKey, true);
+        verify(amqpTransport).autoCreateAndBind(exchange, exchangeType.toString(), queue, routingKey, true);
 
         verify(channel, times(1)).exchangeDeclare(exchange, exchangeType.toString(), true);
         verify(channel, times(1)).queueDeclare(queue, true, false, false, null);


### PR DESCRIPTION
This is a helper that will auto create the exchange, queue and bind them together if they don't already exist. These are not dynamic queues as they don't auto delete. Reduces manual creation and config in rabbitMQ webUI. Also useful for fanout exchanges with a auto named queue per host. 