### PR TITLE
OC-1999: use slf4j instead of log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,9 +166,9 @@
             <version>3.3.1</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.12</version>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncQueueConsumer.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncQueueConsumer.java
@@ -8,7 +8,8 @@ import io.rtr.conduit.amqp.AMQPAsyncConsumerCallback;
 import io.rtr.conduit.amqp.AMQPMessageBundle;
 import io.rtr.conduit.amqp.ActionResponse;
 import io.rtr.conduit.amqp.AsyncResponse;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -17,7 +18,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 public class AMQPAsyncQueueConsumer extends AMQPQueueConsumer implements AsyncResponse {
-    private static final Logger log = Logger.getLogger(AMQPQueueConsumer.class);
+    private static final Logger log = LoggerFactory.getLogger(AMQPAsyncQueueConsumer.class);
     private final AMQPAsyncConsumerCallback callback;
     private final Map<Long, AMQPMessageBundle> unacknowledgedMessages = new LinkedHashMap<Long, AMQPMessageBundle>();
 

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPQueueConsumer.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPQueueConsumer.java
@@ -8,14 +8,15 @@ import com.rabbitmq.client.ShutdownSignalException;
 import io.rtr.conduit.amqp.AMQPConsumerCallback;
 import io.rtr.conduit.amqp.AMQPMessageBundle;
 import io.rtr.conduit.amqp.ActionResponse;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 public class AMQPQueueConsumer extends DefaultConsumer {
-    private static final Logger log = Logger.getLogger(AMQPQueueConsumer.class);
+    private static final Logger log = LoggerFactory.getLogger(AMQPQueueConsumer.class);
     private static final String HEADER_RETRY_COUNT = "conduit-retry-count";
     private AMQPConsumerCallback callback;
     private int threshold;


### PR DESCRIPTION
As a library, Conduit should not be depending on a concrete logger, and
instead should depend on a logging interface (facade) like SLF4j