### PR TITLE
JIF-30: Upgrade RabbitMQ client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ install: echo "I trust Maven."
 # don't just run the tests, also run Findbugs and friends
 script: mvn verify
 
+# required for jdk7
+dist: precise
+
 jdk:
   - openjdk7
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ dist: precise
 jdk:
   - openjdk7
   - oraclejdk7
+
+# turn on TLS 1.2 for maven so the build doesn't fail
+before_script:
+  - echo "MAVEN_OPTS='-Dhttps.protocols=TLSv1.2'" > ~/.mavenrc

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
-            <version>3.3.1</version>
+            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -174,6 +174,14 @@
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <version>3.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Required to make PowerMock/Javassist happy -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -226,6 +234,15 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                     </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.10</version>
+                <configuration>
+                    <argLine>-XX:-UseSplitVerifier</argLine>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Bumped to the recommended version.  Only breaking compilation changes was the addition of the `TimeoutException`, which I assume was previously thrown as `IOException`, so for now, I'm wrapping it in an `IOException` and propagating it that way.

I also had to refactor some stuff in the unit test to fix PowerMock/javassist issues.