### PR TITLE
[YPPY-1615] - Get release process working

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,14 @@
 name: Release
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
-      - master
+      - 'master'
 
 jobs:
   release:
+    if: github.event.pull_request.merged == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -18,21 +20,41 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Perform Maven Release
-        uses: qcastel/github-actions-maven-release@master
+      - name: Configure git
+        run: |
+          git config --global user.email "infrastructure+deploy@renttherunway.com"
+          git config --global user.name "rtr-deploy"
+
+      - name: Setup GPG
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+        run: |
+          echo "$GPG_KEY" | base64 -d > private.key
+          gpg --import --no-tty --batch --yes ./private.key
+          rm ./private.key
+
+      - name: Setup Nexus authentication
+        uses: s4u/maven-settings-action@v2.1.0
         with:
-          release-branch-name: "master"
+          servers: '[
+          {
+            "id": "sonatype-nexus-staging",
+            "username": "${{ secrets.OSS_NEXUS_USERNAME }}",
+            "password": "${{ secrets.OSS_NEXUS_PASSWORD }}"
+          },
+          {
+            "id": "sonatype-nexus-snapshots",
+            "username": "${{ secrets.OSS_NEXUS_USERNAME }}",
+            "password": "${{ secrets.OSS_NEXUS_PASSWORD }}"
+          }]'
 
-          git-release-bot-name: "rtr-actions"
-          git-release-bot-email: "infrastructure+github@renttherunway.com"
+      - name: Setup Github SSH key
+        uses: webfactory/ssh-agent@v0.4.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
 
-          gpg-enabled: "true"
-          gpg-key-id: ${{ secrets.GPG_KEY_ID }}
-          gpg-key: ${{ secrets.GPG_KEY }}
+      - name: Prepare release
+        run: mvn -B release:prepare
 
-          maven-repo-server-username: ${{ secrets.OSS_NEXUS_USERNAME }}
-          maven-repo-server-password: ${{ secrets.OSS_NEXUS_PASSWORD }}
-
-          maven-args: "--no-transfer-progress"
-
-          access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      - name: Perform release
+        run: mvn -B release:perform

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [closed]
     branches:
-      - 'master'
+      - master
 
 jobs:
   release:
@@ -58,3 +58,7 @@ jobs:
 
       - name: Perform release
         run: mvn -B release:perform
+
+      - name: A step failed
+        if: ${{ failure() }}
+        run: mvn release:rollback

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ A simple abstraction over the rabbitmq java client, which hides most of the amqp
 ## How do I publish?
 
     Publisher p = new Publisher(new AMQPPublishContext(
-            username
-          , password
-          , exchange
-          , routing-key
-          , host
-          , port
+            username,
+            password,
+            exchange,
+            routing-key,
+            host,
+            port
     ));
     p.connect();
     p.publish(new AMQPMessageBundle("hello-world");
@@ -20,13 +20,13 @@ A simple abstraction over the rabbitmq java client, which hides most of the amqp
 ## How do I consume?
 
     Consumer c = new Consumer(AMQPListenContext(
-            username
-          , password
-          , exchange
-          , queue
-          , host
-          , port
-          , new AMQPConsumerCallback() {
+            username, 
+            password,
+            exchange,
+            queue,
+            host,
+            port, 
+            new AMQPConsumerCallback() {
                     @Override
                     void notifyOfActionFailure(Exception e) {}
 
@@ -48,3 +48,6 @@ If we can hit that bullseye, the rest of the dominoes will fall like a house of 
 
 As of July 2019, Java 8 is supported.
 Support for Java 6 and Java 7 has ended.
+
+## Release process
+When a PR is merged to master, a release will be made and deployed to Sonatype by Github Actions. This includes pushing new commits via `maven-release-plugin`. The released version will be automatically deployed and usable immediately after the `release` workflow completes.

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
                         <extensions>true</extensions>
                         <inherited>false</inherited>
                         <configuration>
-                            <serverId>sonatype-nexus-snapshots</serverId> <!-- Change to sonatype-nexus-staging -->
+                            <serverId>sonatype-nexus-staging</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <stagingProfileId>5db1fdef03b4db</stagingProfileId>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>


### PR DESCRIPTION
Setup github action to automatically release and deploy.

Runs after successful merge to master rather than push to master, to avoid loops with maven-release-plugin