### PR TITLE
Manage worker thread pool so we know when it stops

### DIFF
--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
@@ -193,12 +193,8 @@ public class AMQPTransport extends AbstractAMQPTransport {
     }
 
     @Override
-    protected boolean isStoppedImpl(int waitForMillis) {
-        try {
-            return executor.awaitTermination(waitForMillis, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            return false; // interrupted while waiting for termination
-        }
+    protected boolean isStoppedImpl(int waitForMillis) throws InterruptedException {
+        return executor.awaitTermination(waitForMillis, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/src/main/java/io/rtr/conduit/amqp/transport/Transport.java
+++ b/src/main/java/io/rtr/conduit/amqp/transport/Transport.java
@@ -34,7 +34,7 @@ public abstract class Transport {
     }
 
     // Is the listener thread pool still doing work? (stop is not synchronous)
-    public final boolean isStopped(int maxWaitMilliseconds)  {
+    public final boolean isStopped(int maxWaitMilliseconds) throws InterruptedException {
         return isStoppedImpl(maxWaitMilliseconds);
     }
 
@@ -57,7 +57,7 @@ public abstract class Transport {
 
     protected void listenImpl(TransportListenProperties properties) throws IOException {}
     protected void stopImpl() throws IOException {}
-    protected abstract boolean isStoppedImpl(int waitMillSeconds);
+    protected abstract boolean isStoppedImpl(int waitMillSeconds) throws InterruptedException;
 
     protected boolean publishImpl(TransportMessageBundle messageBundle, TransportPublishProperties properties)
             throws IOException, TimeoutException, InterruptedException { return false; }

--- a/src/main/java/io/rtr/conduit/amqp/transport/Transport.java
+++ b/src/main/java/io/rtr/conduit/amqp/transport/Transport.java
@@ -33,6 +33,11 @@ public abstract class Transport {
         stopImpl();
     }
 
+    // Is the listener thread pool still doing work? (stop is not synchronous)
+    public final boolean isStopped(int maxWaitMilliseconds)  {
+        return isStoppedImpl(maxWaitMilliseconds);
+    }
+
     //! Publish a message to the other endpoint.
     public final boolean publish(TransportMessageBundle messageBundle, TransportPublishProperties properties)
             throws IOException, TimeoutException, InterruptedException {
@@ -52,6 +57,8 @@ public abstract class Transport {
 
     protected void listenImpl(TransportListenProperties properties) throws IOException {}
     protected void stopImpl() throws IOException {}
+    protected abstract boolean isStoppedImpl(int waitMillSeconds);
+
     protected boolean publishImpl(TransportMessageBundle messageBundle, TransportPublishProperties properties)
             throws IOException, TimeoutException, InterruptedException { return false; }
     protected <E> boolean transactionalPublishImpl(Collection<E> messageBundles, TransportPublishProperties properties)

--- a/src/main/java/io/rtr/conduit/amqp/transport/TransportExecutor.java
+++ b/src/main/java/io/rtr/conduit/amqp/transport/TransportExecutor.java
@@ -1,0 +1,39 @@
+package io.rtr.conduit.amqp.transport;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TransportExecutor extends ThreadPoolExecutor {
+
+    // From ConsumerWorkService
+    private static final int DEFAULT_NUM_THREADS = Runtime.getRuntime().availableProcessors() * 2;
+
+    private static ThreadFactory buildCountedDaemonThreadFactory() {
+        AtomicInteger threadCount = new AtomicInteger(0);
+        return run -> {
+            Thread thread = new Thread(run);
+            thread.setDaemon(true);
+            thread.setName(String.format("AMQPConnection-%s", threadCount.getAndIncrement()));
+            return thread;
+        };
+    }
+
+    public TransportExecutor() {
+        this(DEFAULT_NUM_THREADS, buildCountedDaemonThreadFactory());
+    }
+
+    /**
+     * Based on Executors.newFixedThreadPool
+     * @param nThreads
+     * @param threadFactory
+     */
+    public TransportExecutor(int nThreads, ThreadFactory threadFactory) {
+        super(nThreads, nThreads,
+                0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<Runnable>(),
+                threadFactory);
+    }
+}


### PR DESCRIPTION
Currently, `AMQPTransport` relies on a thread pool which is private to the the rabbitMQ `Connection`. The consequence is that it's not possible to know when the workers listening to a `Channel` have finished processing. We have a case where resources are being terminated before the workers have finished, even though the channel has already been `stop`ped.
