### PR TITLE
Adding support for multiplexing several channels over a single connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
         </profile>
     </profiles>
 
+    <properties>
+        <jacoco.version>0.8.6</jacoco.version>
+    </properties>
+
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -182,6 +187,26 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
@@ -4,8 +4,8 @@ import com.rabbitmq.client.MetricsCollector;
 import io.rtr.conduit.amqp.AMQPAsyncConsumerCallback;
 
 public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTransport
-                                                                , AMQPAsyncListenProperties
-                                                                , AMQPAsyncConsumerBuilder> {
+        , AMQPAsyncListenProperties
+        , AMQPAsyncConsumerBuilder> {
     private AMQPAsyncConsumerCallback callback;
     private MetricsCollector metricsCollector;
 
@@ -29,7 +29,7 @@ public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTrans
 
     @Override
     protected AMQPAsyncTransport buildTransport() {
-        if (getSharedConnection()!=null) {
+        if (getSharedConnection() != null) {
             return new AMQPAsyncTransport(getSharedConnection());
         } else {
             return new AMQPAsyncTransport(isSsl(), getHost(), getPort(), metricsCollector);
@@ -55,8 +55,8 @@ public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTrans
 
     @Override
     protected AMQPListenContext buildListenContext(AMQPAsyncTransport transport
-                                                 , AMQPConnectionProperties connectionProperties
-                                                 , AMQPAsyncListenProperties amqpAsyncListenProperties) {
+            , AMQPConnectionProperties connectionProperties
+            , AMQPAsyncListenProperties amqpAsyncListenProperties) {
         return new AMQPListenContext(transport, connectionProperties, amqpAsyncListenProperties);
     }
 }

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
@@ -29,7 +29,11 @@ public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTrans
 
     @Override
     protected AMQPAsyncTransport buildTransport() {
-        return new AMQPAsyncTransport(isSsl(), getHost(), getPort(), metricsCollector);
+        if (getSharedConnection()!=null) {
+            return new AMQPAsyncTransport(getSharedConnection());
+        } else {
+            return new AMQPAsyncTransport(isSsl(), getHost(), getPort(), metricsCollector);
+        }
     }
 
     @Override

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
@@ -13,7 +13,7 @@ public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTrans
         return new AMQPAsyncConsumerBuilder();
     }
 
-    private AMQPAsyncConsumerBuilder() {
+    protected AMQPAsyncConsumerBuilder() {
         super.prefetchCount(100);
     }
 

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncTransport.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncTransport.java
@@ -9,6 +9,10 @@ public class AMQPAsyncTransport extends AMQPTransport {
         super(ssl, host, port, metricsCollector);
     }
 
+    public AMQPAsyncTransport(AMQPConnection sharedConnection) {
+        super(sharedConnection);
+    }
+
     @Override
     protected AMQPQueueConsumer getConsumer(Object callback, AMQPCommonListenProperties commonListenProperties, String poisonPrefix){
         return new AMQPAsyncQueueConsumer(

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPConnection.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPConnection.java
@@ -1,0 +1,102 @@
+package io.rtr.conduit.amqp.impl;
+
+import com.rabbitmq.client.AlreadyClosedException;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.MetricsCollector;
+import io.rtr.conduit.amqp.transport.TransportExecutor;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+public class AMQPConnection {
+    private final ConnectionFactory connectionFactory;
+    private Connection connection;
+    private TransportExecutor executor;
+    private final Supplier<TransportExecutor> executorFactory;
+
+    public AMQPConnection(boolean ssl, String host, int port, MetricsCollector metricsCollector) {
+        this(new ConnectionFactory(), TransportExecutor::new, ssl, host, port, metricsCollector);
+    }
+
+    public AMQPConnection(ConnectionFactory factory, Supplier<TransportExecutor> executorFactory, boolean ssl, String host, int port, MetricsCollector metricsCollector) {
+        this.connectionFactory =factory;
+        this.executorFactory = executorFactory;
+        if (ssl) {
+            factory.setSocketFactory(SSLSocketFactory.getDefault());
+        }
+
+        factory.setHost(host);
+        factory.setPort(port);
+
+        if (metricsCollector != null) {
+            factory.setMetricsCollector(metricsCollector);
+        }
+    }
+
+    public boolean isConnected() {
+        return this.connection != null && this.connection.isOpen();
+    }
+
+    public synchronized void connect(AMQPConnectionProperties properties) throws IOException, TimeoutException {
+        if (isConnected()) {
+            return;
+        }
+        configureConnectionFactory(properties);
+        initializeExecutor();
+        connection = connectionFactory.newConnection(executor);
+    }
+
+    public synchronized void disconnect() throws IOException {
+        //! We are going to assume that closing an already closed
+        //  connection is considered success.
+        if (connection != null && connection.isOpen()) {
+            try {
+                connection.close(connectionFactory.getConnectionTimeout());
+            } catch (AlreadyClosedException ignored) {}
+        }
+        stopListening();
+    }
+
+    public Channel createChannel() throws IOException {
+        if (!isConnected()) {
+            throw new IllegalStateException("Attempted to create channel whilst disconnected.");
+        }
+        Channel channel = connection.createChannel();
+        channel.basicQos(1);
+        return channel;
+    }
+
+    public void stopListening() {
+        if (executor != null) {
+            executor.shutdown();
+            executor = null;
+        }
+    }
+
+    public boolean waitToStopListening(int waitForMillis) throws InterruptedException {
+        if (executor != null) {
+            return executor.awaitTermination(waitForMillis, TimeUnit.MILLISECONDS);
+        }
+        return true;
+    }
+
+    private void initializeExecutor() {
+        stopListening();
+        executor = executorFactory.get();
+    }
+
+    private void configureConnectionFactory(AMQPConnectionProperties properties) {
+        connectionFactory.setUsername(properties.getUsername());
+        connectionFactory.setPassword(properties.getPassword());
+        connectionFactory.setVirtualHost(properties.getVirtualHost());
+        connectionFactory.setConnectionTimeout(properties.getConnectionTimeout());
+        connectionFactory.setRequestedHeartbeat(properties.getHeartbeatInterval());
+        connectionFactory.setAutomaticRecoveryEnabled(properties.isAutomaticRecoveryEnabled());
+    }
+
+}

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPConnection.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPConnection.java
@@ -55,9 +55,10 @@ public class AMQPConnection {
     public synchronized void disconnect() throws IOException {
         //! We are going to assume that closing an already closed
         //  connection is considered success.
-        if (connection != null && connection.isOpen()) {
+        if (isConnected()) {
             try {
                 connection.close(connectionFactory.getConnectionTimeout());
+                connection = null;
             } catch (AlreadyClosedException ignored) {}
         }
         stopListening();

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPConnection.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPConnection.java
@@ -9,6 +9,7 @@ import io.rtr.conduit.amqp.transport.TransportExecutor;
 
 import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -78,9 +79,9 @@ public class AMQPConnection {
         }
     }
 
-    public boolean waitToStopListening(int waitForMillis) throws InterruptedException {
+    public boolean waitToStopListening(Duration waitFor) throws InterruptedException {
         if (executor != null) {
-            return executor.awaitTermination(waitForMillis, TimeUnit.MILLISECONDS);
+            return executor.awaitTermination(waitFor.toMillis(), TimeUnit.MILLISECONDS);
         }
         return true;
     }

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPConnectionProperties.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPConnectionProperties.java
@@ -2,25 +2,75 @@ package io.rtr.conduit.amqp.impl;
 
 import io.rtr.conduit.amqp.transport.TransportConnectionProperties;
 
-public class AMQPConnectionProperties implements TransportConnectionProperties {
-    private String username;
-    private String password;
-    private String virtualHost;
-    private int connectionTimeout;
-    private int heartbeatInterval;
-    private boolean automaticRecoveryEnabled;
+import java.time.Duration;
+import java.util.function.BiConsumer;
 
-    AMQPConnectionProperties(String username, String password, String virtualHost) {
-        this.username = username;
-        this.password = password;
-        this.virtualHost = virtualHost;
-        this.connectionTimeout = 10000; //! In milliseconds.
-        this.heartbeatInterval = 60; //! In seconds.
-        this.automaticRecoveryEnabled = true;
+public class AMQPConnectionProperties implements TransportConnectionProperties {
+
+    public static class Builder {
+        private String username;
+        private String password;
+        private String virtualHost = "/";
+        private Duration connectionTimeout = Duration.ofSeconds(10);
+        private Duration heartbeatInterval = Duration.ofSeconds(60);
+        private boolean automaticRecoveryEnabled;
+
+        private Builder() {}
+
+        public Builder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder virtualHost(String virtualHost) {
+            this.virtualHost = virtualHost;
+            return this;
+        }
+
+        public Builder connectionTimeout(Duration connectionTimeout) {
+            this.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        public Builder heartbeatInterval(Duration heartbeatInterval) {
+            this.heartbeatInterval = heartbeatInterval;
+            return this;
+        }
+
+        public Builder automaticRecoveryEnabled(boolean automaticRecoveryEnabled) {
+            this.automaticRecoveryEnabled = automaticRecoveryEnabled;
+            return this;
+        }
+
+        public AMQPConnectionProperties build() {
+            return new AMQPConnectionProperties(
+                    username, password, virtualHost, (int)connectionTimeout.toMillis(), (int)heartbeatInterval.getSeconds(), automaticRecoveryEnabled
+            );
+        }
     }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private final String username;
+    private final String password;
+    private final String virtualHost;
+    private final int connectionTimeout;
+    private final int heartbeatInterval;
+    private final boolean automaticRecoveryEnabled;
 
     AMQPConnectionProperties(String username, String password) {
         this(username, password, "/");
+    }
+
+    AMQPConnectionProperties(String username, String password, String virtualHost) {
+        this(username, password, virtualHost, 10000, 60, true);
     }
 
     AMQPConnectionProperties(String username
@@ -28,11 +78,8 @@ public class AMQPConnectionProperties implements TransportConnectionProperties {
                                   , String virtualHost
                                   , int connectionTimeout
                                   , int heartbeatInterval) {
-        this.username = username;
-        this.password = password;
-        this.virtualHost = virtualHost;
-        this.connectionTimeout = connectionTimeout;
-        this.heartbeatInterval = heartbeatInterval;
+        //Different default automaticRecoveryEnabled for this constructor is weird, but it was preexisting logic retained for compatibility
+        this(username, password, virtualHost, connectionTimeout, heartbeatInterval, false);
     }
 
     AMQPConnectionProperties(String username
@@ -72,4 +119,5 @@ public class AMQPConnectionProperties implements TransportConnectionProperties {
     public boolean isAutomaticRecoveryEnabled() {
         return automaticRecoveryEnabled;
     }
+
 }

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
@@ -5,12 +5,12 @@ import io.rtr.conduit.amqp.transport.Transport;
 import io.rtr.conduit.amqp.transport.TransportListenProperties;
 
 public abstract class AMQPConsumerBuilder<T extends Transport
-                                        , L extends TransportListenProperties
-                                        , R extends AMQPConsumerBuilder>
-                      extends ConsumerBuilder<T
-                                            , AMQPConnectionProperties
-                                            , L
-                                            , AMQPListenContext> {
+        , L extends TransportListenProperties
+        , R extends AMQPConsumerBuilder>
+        extends ConsumerBuilder<T
+        , AMQPConnectionProperties
+        , L
+        , AMQPListenContext> {
     private String username;
     private String password;
     private String exchange;
@@ -46,7 +46,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     }
 
     private R builder() {
-        return (R)this;
+        return (R) this;
     }
 
     public R username(String username) {
@@ -164,8 +164,8 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     }
 
     public R poisonQueueEnabled(boolean enabled) {
-    	this.poisonQueueEnabled = enabled;
-    	return builder();
+        this.poisonQueueEnabled = enabled;
+        return builder();
     }
 
     /*
@@ -222,7 +222,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     }
 
     protected boolean isPoisonQueueEnabled() {
-    	return poisonQueueEnabled;
+        return poisonQueueEnabled;
     }
 
     @Override
@@ -231,10 +231,9 @@ public abstract class AMQPConsumerBuilder<T extends Transport
         if (dynamicQueueCreation && autoCreateAndBind) {
             throw new IllegalArgumentException("Both dynamicQueueCreation and autoCreateAndBind are enabled.");
         }
-        if(!dynamicQueueCreation){
+        if (!dynamicQueueCreation) {
             assertNotNull(queue, "queue");
-        }
-        else{
+        } else {
             assertNotNull(dynamicQueueRoutingKey, "dynamicQueueRoutingKey");
         }
         if (autoCreateAndBind) {
@@ -245,7 +244,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
                 throw new IllegalArgumentException("Fanout exchanges do not support poison queues");
             }
         }
-        if (sharedConnection!=null && (username!=null || password != null || !virtualHost.equals("/"))) {
+        if (sharedConnection != null && (username != null || password != null || !virtualHost.equals("/"))) {
             throw new IllegalArgumentException(
                     String.format("Username ('%s'), password ('%s') or virtualHost ('%s') should not be specified for a consumer if using a shared connection, it only needs these if using it's own private connection.", username, password, virtualHost)
             );

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
@@ -6,7 +6,7 @@ import io.rtr.conduit.amqp.transport.TransportListenProperties;
 
 public abstract class AMQPConsumerBuilder<T extends Transport
         , L extends TransportListenProperties
-        , R extends AMQPConsumerBuilder>
+        , R extends AMQPConsumerBuilder<?,?,?>>
         extends ConsumerBuilder<T
         , AMQPConnectionProperties
         , L

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
@@ -18,6 +18,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     private boolean ssl;
     private String host = "localhost";
     private int port = 5672;
+    private AMQPConnection sharedConnection;
     private String virtualHost = "/";
     private int connectionTimeout = 10000; //! In milliseconds.
     private int heartbeatInterval = 60; //! In seconds.
@@ -143,10 +144,20 @@ public abstract class AMQPConsumerBuilder<T extends Transport
         return port;
     }
 
+    public R sharedConnection(AMQPConnection connection) {
+        sharedConnection = connection;
+        return builder();
+    }
+
+    public AMQPConnection getSharedConnection() {
+        return sharedConnection;
+    }
+
     public R retryThreshold(int retryThreshold) {
         this.retryThreshold = retryThreshold;
         return builder();
     }
+
 
     protected int getRetryThreshold() {
         return retryThreshold;
@@ -234,6 +245,12 @@ public abstract class AMQPConsumerBuilder<T extends Transport
                 throw new IllegalArgumentException("Fanout exchanges do not support poison queues");
             }
         }
+        if (sharedConnection!=null && (username!=null || password != null || !virtualHost.equals("/"))) {
+            throw new IllegalArgumentException(
+                    String.format("Username ('%s'), password ('%s') or virtualHost ('%s') should not be specified for a consumer if using a shared connection, it only needs these if using it's own private connection.", username, password, virtualHost)
+            );
+        }
+
     }
 
     @Override

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPPublisherBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPPublisherBuilder.java
@@ -16,6 +16,7 @@ public class AMQPPublisherBuilder extends PublisherBuilder<AMQPTransport
     protected String host = "localhost";
     protected String virtualHost = "/";
     protected int port = 5672;
+    private AMQPConnection sharedConnection;
     protected int publishTimeout = 100;
     protected int connectionTimeout = 10000; //! In milliseconds
     protected int heartbeatInterval = 60; //! In seconds
@@ -60,6 +61,15 @@ public class AMQPPublisherBuilder extends PublisherBuilder<AMQPTransport
         return this;
     }
 
+    public AMQPPublisherBuilder sharedConnection(AMQPConnection connection) {
+        sharedConnection = connection;
+        return builder();
+    }
+
+    public AMQPConnection getSharedConnection() {
+        return sharedConnection;
+    }
+
     public AMQPPublisherBuilder publishTimeout(int timeout) {
         this.publishTimeout = timeout;
         return this;
@@ -102,7 +112,11 @@ public class AMQPPublisherBuilder extends PublisherBuilder<AMQPTransport
 
     @Override
     protected AMQPTransport buildTransport() {
-        return new AMQPTransport(ssl, host, port, metricsCollector);
+        if (getSharedConnection()!=null) {
+            return new AMQPTransport(getSharedConnection());
+        } else {
+            return new AMQPTransport(ssl, host, port, metricsCollector);
+        }
     }
 
     @Override

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPPublisherBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPPublisherBuilder.java
@@ -112,7 +112,7 @@ public class AMQPPublisherBuilder extends PublisherBuilder<AMQPTransport
 
     @Override
     protected AMQPTransport buildTransport() {
-        if (getSharedConnection()!=null) {
+        if (getSharedConnection() != null) {
             return new AMQPTransport(getSharedConnection());
         } else {
             return new AMQPTransport(ssl, host, port, metricsCollector);

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
@@ -29,7 +29,11 @@ public class AMQPSyncConsumerBuilder extends AMQPConsumerBuilder<AMQPTransport
 
     @Override
     protected AMQPTransport buildTransport() {
-        return new AMQPTransport(isSsl(), getHost(), getPort(), metricsCollector);
+        if (getSharedConnection()!=null) {
+            return new AMQPTransport(getSharedConnection());
+        } else {
+            return new AMQPTransport(isSsl(), getHost(), getPort(), metricsCollector);
+        }
     }
 
     @Override

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
@@ -13,7 +13,7 @@ public class AMQPSyncConsumerBuilder extends AMQPConsumerBuilder<AMQPTransport
         return new AMQPSyncConsumerBuilder();
     }
 
-    private AMQPSyncConsumerBuilder() {
+    protected AMQPSyncConsumerBuilder() {
         super.prefetchCount(1);
     }
 

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
@@ -4,8 +4,8 @@ import com.rabbitmq.client.MetricsCollector;
 import io.rtr.conduit.amqp.AMQPConsumerCallback;
 
 public class AMQPSyncConsumerBuilder extends AMQPConsumerBuilder<AMQPTransport
-                                                               , AMQPListenProperties
-                                                               , AMQPSyncConsumerBuilder> {
+        , AMQPListenProperties
+        , AMQPSyncConsumerBuilder> {
     private AMQPConsumerCallback callback;
     private MetricsCollector metricsCollector;
 
@@ -29,7 +29,7 @@ public class AMQPSyncConsumerBuilder extends AMQPConsumerBuilder<AMQPTransport
 
     @Override
     protected AMQPTransport buildTransport() {
-        if (getSharedConnection()!=null) {
+        if (getSharedConnection() != null) {
             return new AMQPTransport(getSharedConnection());
         } else {
             return new AMQPTransport(isSsl(), getHost(), getPort(), metricsCollector);
@@ -55,8 +55,8 @@ public class AMQPSyncConsumerBuilder extends AMQPConsumerBuilder<AMQPTransport
 
     @Override
     protected AMQPListenContext buildListenContext(AMQPTransport transport
-                                                 , AMQPConnectionProperties connectionProperties
-                                                 , AMQPListenProperties listenProperties) {
+            , AMQPConnectionProperties connectionProperties
+            , AMQPListenProperties listenProperties) {
         return new AMQPListenContext(transport, connectionProperties, listenProperties);
     }
 }

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
@@ -80,7 +80,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
     }
 
     @Override
-    protected AMQPQueueConsumer getConsumer(Object callback, AMQPCommonListenProperties commonListenProperties, String poisonPrefix){
+    protected AMQPQueueConsumer getConsumer(Object callback, AMQPCommonListenProperties commonListenProperties, String poisonPrefix) {
         return new AMQPQueueConsumer(
                 getChannel(),
                 (AMQPConsumerCallback) callback,
@@ -92,12 +92,12 @@ public class AMQPTransport extends AbstractAMQPTransport {
 
     @Override
     protected AMQPCommonListenProperties getCommonListenProperties(TransportListenProperties properties) {
-        return (AMQPListenProperties)properties;
+        return (AMQPListenProperties) properties;
     }
 
     @Override
     protected Object getConsumerCallback(TransportListenProperties properties) {
-        return ((AMQPListenProperties)properties).getCallback();
+        return ((AMQPListenProperties) properties).getCallback();
     }
 
     @Override
@@ -107,12 +107,12 @@ public class AMQPTransport extends AbstractAMQPTransport {
         String queue = commonListenProperties.getQueue();
         String poisonPrefix = commonListenProperties.getPoisonPrefix();
 
-        if(commonListenProperties.isDynamicQueueCreation()) {
+        if (commonListenProperties.isDynamicQueueCreation()) {
             queue = createDynamicQueue(commonListenProperties.getExchange(),
                     commonListenProperties.getDynamicQueueRoutingKey(),
                     commonListenProperties.isPoisonQueueEnabled());
             poisonPrefix = "." + queue;
-        } else if(commonListenProperties.isAutoCreateAndBind()) {
+        } else if (commonListenProperties.isAutoCreateAndBind()) {
             autoCreateAndBind(
                     commonListenProperties.getExchange(),
                     commonListenProperties.getExchangeType(),
@@ -121,7 +121,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
                     commonListenProperties.isPoisonQueueEnabled());
         }
 
-        if(commonListenProperties.shouldPurgeOnConnect()){
+        if (commonListenProperties.shouldPurgeOnConnect()) {
             channel.queuePurge(queue);
         }
 
@@ -138,7 +138,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
                                         boolean isPoisonQueueEnabled) throws IOException {
         String queue = channel.queueDeclare().getQueue();
         channel.queueBind(queue, exchange, routingKey);
-        if(isPoisonQueueEnabled){
+        if (isPoisonQueueEnabled) {
             String poisonQueue = POISON + "." + queue;
             Map<String, Object> settings = new HashMap<String, Object>();
             channel.queueDeclare(poisonQueue, true, true, true, settings);
@@ -152,7 +152,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
         channel.exchangeDeclare(exchange, exchangeType, true);
         channel.queueDeclare(queue, true, false, false, null);
         channel.queueBind(queue, exchange, routingKey);
-        if(isPoisonQueueEnabled){
+        if (isPoisonQueueEnabled) {
             String poisonQueue = queue + POISON;
             channel.queueDeclare(poisonQueue, true, false, false, null);
             channel.queueBind(poisonQueue, exchange, routingKey + POISON);
@@ -181,17 +181,16 @@ public class AMQPTransport extends AbstractAMQPTransport {
     protected boolean isStoppedImpl(int waitForMillis) throws InterruptedException {
         if (hasPrivateConnection) {
             return conn.waitToStopListening(Duration.ofMillis(waitForMillis));
-        }
-        else {
-            return (channel==null || !channel.isOpen());
+        } else {
+            return (channel == null || !channel.isOpen());
         }
     }
 
     @Override
     protected boolean publishImpl(TransportMessageBundle bundle, TransportPublishProperties properties)
             throws IOException, TimeoutException, InterruptedException {
-        AMQPPublishProperties publishProperties = (AMQPPublishProperties)properties;
-        AMQPMessageBundle messageBundle = (AMQPMessageBundle)bundle;
+        AMQPPublishProperties publishProperties = (AMQPPublishProperties) properties;
+        AMQPMessageBundle messageBundle = (AMQPMessageBundle) bundle;
 
         if (publishProperties.isConfirmEnabled()) {
             channel.confirmSelect();
@@ -199,9 +198,9 @@ public class AMQPTransport extends AbstractAMQPTransport {
 
         channel.basicPublish(
                 publishProperties.getExchange()
-              , publishProperties.getRoutingKey()
-              , messageBundle.getBasicProperties()
-              , messageBundle.getBody()
+                , publishProperties.getRoutingKey()
+                , messageBundle.getBasicProperties()
+                , messageBundle.getBody()
         );
 
         if (publishProperties.isConfirmEnabled()) {
@@ -220,7 +219,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
 
         try {
             for (E messageBundle : messageBundles) {
-                if (!publishImpl((AMQPMessageBundle)messageBundle, properties))
+                if (!publishImpl((AMQPMessageBundle) messageBundle, properties))
                     return false;
             }
             rollback = false;
@@ -241,7 +240,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
     }
 
     //Package private for testing
-    void setConnection(AMQPConnection connection){
+    void setConnection(AMQPConnection connection) {
         this.conn = connection;
     }
 }

--- a/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
+++ b/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
@@ -2,25 +2,19 @@ package io.rtr.conduit.amqp.impl;
 
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.Connection;
-import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.MetricsCollector;
 import io.rtr.conduit.amqp.AMQPConsumerCallback;
 import io.rtr.conduit.amqp.AMQPMessageBundle;
 import io.rtr.conduit.amqp.AbstractAMQPTransport;
 import io.rtr.conduit.amqp.transport.TransportConnectionProperties;
-import io.rtr.conduit.amqp.transport.TransportExecutor;
 import io.rtr.conduit.amqp.transport.TransportListenProperties;
 import io.rtr.conduit.amqp.transport.TransportMessageBundle;
 import io.rtr.conduit.amqp.transport.TransportPublishProperties;
-
-import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public class AMQPTransport extends AbstractAMQPTransport {
@@ -29,11 +23,11 @@ public class AMQPTransport extends AbstractAMQPTransport {
     private Channel channel;
     static final String POISON = ".poison";
 
-    AMQPTransport(boolean ssl, String host, int port, MetricsCollector metricsCollector) {
+    protected AMQPTransport(boolean ssl, String host, int port, MetricsCollector metricsCollector) {
         this(new AMQPConnection(ssl, host, port, metricsCollector), true);
     }
 
-    public AMQPTransport(AMQPConnection sharedConnection) {
+    protected AMQPTransport(AMQPConnection sharedConnection) {
         this(sharedConnection, false);
     }
 

--- a/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
+++ b/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
@@ -1,9 +1,11 @@
 package io.rtr.conduit.amqp.impl;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 public class AMQPAsyncConsumerBuilderTest {
 
@@ -117,5 +119,16 @@ public class AMQPAsyncConsumerBuilderTest {
         assertEquals("When poisonPrefix not set, default to ", "", commonListenProperties.getPoisonPrefix());
         assertEquals("When poisonQEnabled not set, default to ", true, commonListenProperties.isPoisonQueueEnabled());
         amqpAsyncConsumerBuilder.build();
+    }
+
+    @Test
+    public void testSettingCredsAndSharedConnectionThrows(){
+        AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
+                .exchange("exchange")
+                .queue("queue")
+                .username("bob")
+                .sharedConnection(mock(AMQPConnection.class));
+
+        Assert.assertThrows(IllegalArgumentException.class, amqpAsyncConsumerBuilder::build);
     }
 }

--- a/src/test/java/io/rtr/conduit/amqp/impl/AMQPConnectionPropertiesTest.java
+++ b/src/test/java/io/rtr/conduit/amqp/impl/AMQPConnectionPropertiesTest.java
@@ -1,0 +1,26 @@
+package io.rtr.conduit.amqp.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Duration;
+
+public class AMQPConnectionPropertiesTest {
+    @Test
+    public void testValidateBuilder() {
+        AMQPConnectionProperties properties = AMQPConnectionProperties.builder()
+                .username("Anna")
+                .password("Anna's password")
+                .automaticRecoveryEnabled(true)
+                .connectionTimeout(Duration.ofHours(8))
+                .heartbeatInterval(Duration.ofSeconds(2))
+                .virtualHost("Anna's vhost")
+                .build();
+
+        Assert.assertEquals("Anna", properties.getUsername());
+        Assert.assertEquals("Anna's password", properties.getPassword());
+        Assert.assertEquals("Anna's vhost", properties.getVirtualHost());
+        Assert.assertEquals(Duration.ofHours(8).toMillis(), properties.getConnectionTimeout());
+        Assert.assertEquals(2, properties.getHeartbeatInterval());
+    }
+}

--- a/src/test/java/io/rtr/conduit/amqp/impl/AMQPConnectionTest.java
+++ b/src/test/java/io/rtr/conduit/amqp/impl/AMQPConnectionTest.java
@@ -1,0 +1,215 @@
+package io.rtr.conduit.amqp.impl;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.MetricsCollector;
+import io.rtr.conduit.amqp.transport.TransportExecutor;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AMQPConnectionTest {
+    private final static int CONNECTION_TIMEOUT = 1337;
+    private final static int PORT = 42;
+
+    Connection mockConnection;
+    ConnectionFactory mockFactory;
+    TransportExecutor mockExecutor;
+    MetricsCollector mockMetrics;
+
+    private AMQPConnection defaultTestConnection() {
+
+        return new AMQPConnection(mockFactory, ()->mockExecutor, false, "RABBIT HOST", PORT, null);
+    }
+
+    private AMQPConnectionProperties defaultTestConnectionProps() {
+        return new AMQPConnectionProperties(
+                "BOB",
+                "BOBS PASSWORD",
+                "BOBS VHOST",
+                CONNECTION_TIMEOUT,
+                666,
+                true);
+    }
+
+    @Before
+    public void before() throws IOException, TimeoutException {
+        mockFactory = mock(ConnectionFactory.class);
+        mockExecutor = mock(TransportExecutor.class);
+        mockMetrics = mock(MetricsCollector.class);
+
+        mockConnection = mock(Connection.class);
+        when(mockConnection.createChannel()).thenReturn(mock(Channel.class));
+        when(mockConnection.isOpen()).thenReturn(true);
+        doAnswer((i)->when(mockConnection.isOpen())
+                .thenReturn(false))
+                .when(mockConnection).close(anyInt());
+        when(mockFactory.newConnection(mockExecutor)).thenReturn(mockConnection);
+        when(mockFactory.getConnectionTimeout()).thenReturn(CONNECTION_TIMEOUT);
+    }
+
+    @Test
+    public void testConstructor_NoSll_SetsHostPortAndMetrics() throws Exception {
+        new AMQPConnection(mockFactory, ()->mockExecutor, false, "RABBIT HOST", PORT, mockMetrics);
+        verify(mockFactory).setHost("RABBIT HOST");
+        verify(mockFactory).setPort(PORT);
+        verify(mockFactory).setMetricsCollector(mockMetrics);
+        verify(mockFactory, never()).setSocketFactory(any());
+
+    }
+
+    @Test
+    public void testConstructor_Sll_SetsSocketFactory() throws Exception {
+        new AMQPConnection(mockFactory, ()->mockExecutor, true, "RABBIT HOST", PORT, mockMetrics);
+        verify(mockFactory).setHost("RABBIT HOST");
+        verify(mockFactory).setPort(PORT);
+        verify(mockFactory).setMetricsCollector(mockMetrics);
+        verify(mockFactory).setSocketFactory(any());
+
+    }
+
+    @Test
+    public void testConstructor_MetricsNull_SetsNoMetrics() throws Exception {
+        new AMQPConnection(mockFactory, ()->mockExecutor, false, "RABBIT HOST", PORT, null);
+        verify(mockFactory, never()).setMetricsCollector(any());
+    }
+
+    @Test
+    public void testConnect_NotConnected_TransfersPropsToFactoryAndConnects() throws IOException, TimeoutException {
+        defaultTestConnection().connect(defaultTestConnectionProps());
+
+        verify(mockFactory).setUsername("BOB");
+        verify(mockFactory).setPassword("BOBS PASSWORD");
+        verify(mockFactory).setVirtualHost("BOBS VHOST");
+        verify(mockFactory).setConnectionTimeout(CONNECTION_TIMEOUT);
+        verify(mockFactory).setRequestedHeartbeat(666);
+        verify(mockFactory).setAutomaticRecoveryEnabled(true);
+
+        verify(mockFactory).newConnection(mockExecutor);
+    }
+
+    @Test
+    public void testConnect_AlreadyConnected_DoesNothing() throws IOException, TimeoutException {
+        AMQPConnection conn = defaultTestConnection();
+        conn.connect(defaultTestConnectionProps());
+        conn.connect(defaultTestConnectionProps());
+
+        verify(mockFactory, times(1)).newConnection(mockExecutor);
+    }
+
+    @Test
+    public void testDisconnect_Connected_ClosesConnection() throws IOException, TimeoutException {
+        AMQPConnection conn = defaultTestConnection();
+        conn.connect(defaultTestConnectionProps());
+        conn.disconnect();
+
+        verify(mockConnection).close(CONNECTION_TIMEOUT);
+        verify(mockExecutor).shutdown();
+    }
+
+    @Test
+    public void testDisconnect_NotConnected_DoesNothing() throws IOException, TimeoutException {
+        defaultTestConnection().disconnect();
+        verify(mockConnection, never()).close(anyInt());
+        verify(mockExecutor, never()).shutdown();
+    }
+
+    @Test
+    public void testDisconnect_AlreadyDisconnected_DoesNothing() throws IOException, TimeoutException {
+        AMQPConnection conn = defaultTestConnection();
+        conn.connect(defaultTestConnectionProps());
+        conn.disconnect();
+        conn.disconnect();
+
+        verify(mockConnection, times(1)).close(CONNECTION_TIMEOUT);
+        verify(mockExecutor, times(1)).shutdown();
+    }
+
+    @Test
+    public void testStopListening_Connected_OnlyShutsDownExecutor() throws IOException, TimeoutException {
+        AMQPConnection conn = defaultTestConnection();
+        conn.connect(defaultTestConnectionProps());
+        conn.stopListening();
+
+        verify(mockConnection, never()).close(CONNECTION_TIMEOUT);
+        verify(mockExecutor).shutdown();
+    }
+
+    @Test
+    public void testStopListening_NotConnected_DoesNothing() {
+        defaultTestConnection().stopListening();
+        verify(mockExecutor, never()).shutdown();
+    }
+
+    @Test
+    public void testStopListening_MultipleCalls_OnlyShutsDownExecutorOnce() throws IOException, TimeoutException {
+        AMQPConnection conn = defaultTestConnection();
+        conn.connect(defaultTestConnectionProps());
+        conn.stopListening();
+        conn.stopListening();
+        conn.stopListening();
+        conn.stopListening();
+
+        verify(mockConnection, never()).close(CONNECTION_TIMEOUT);
+        verify(mockExecutor, times(1)).shutdown();
+    }
+
+    @Test
+    public void testCreateChannel_Connected_CreatesQos1Channel() throws IOException, TimeoutException {
+        AMQPConnection conn = defaultTestConnection();
+        conn.connect(defaultTestConnectionProps());
+        Channel channel = conn.createChannel();
+        verify(channel).basicQos(1);
+    }
+
+    @Test
+    public void testCreateChannel_NotConnected_Throws() {
+        AMQPConnection conn = defaultTestConnection();
+
+        Assert.assertThrows(IllegalStateException.class, conn::createChannel);
+    }
+
+    @Test
+    public void testIsConnected_Connected_ReturnsTrue() throws IOException, TimeoutException {
+        AMQPConnection conn = defaultTestConnection();
+        Assert.assertFalse(conn.isConnected());
+        conn.connect(defaultTestConnectionProps());
+        Assert.assertTrue(conn.isConnected());
+        conn.disconnect();
+        Assert.assertFalse(conn.isConnected());
+
+        Assert.assertThrows(IllegalStateException.class, conn::createChannel);
+    }
+
+    @Test
+    public void testWaitToStopListening_Connected_CallsAwaitTerminationOnExecutor() throws IOException, TimeoutException, InterruptedException {
+        AMQPConnection conn = defaultTestConnection();
+        conn.connect(defaultTestConnectionProps());
+        when(mockExecutor.awaitTermination(1338, TimeUnit.MILLISECONDS)).thenReturn(true);
+        Assert.assertTrue(conn.waitToStopListening(1338));
+        verify(mockExecutor).awaitTermination(1338, TimeUnit.MILLISECONDS);
+        when(mockExecutor.awaitTermination(1338, TimeUnit.MILLISECONDS)).thenReturn(false);
+        Assert.assertFalse(conn.waitToStopListening(1338));
+        verify(mockExecutor, times(2)).awaitTermination(1338, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testWaitToStopListening_NotConnected_ReturnsTrue() throws IOException, TimeoutException, InterruptedException {
+        Assert.assertTrue(defaultTestConnection().waitToStopListening(1338));
+        verify(mockExecutor, never()).awaitTermination(1338, TimeUnit.MILLISECONDS);
+    }
+}

--- a/src/test/java/io/rtr/conduit/amqp/impl/AMQPConnectionTest.java
+++ b/src/test/java/io/rtr/conduit/amqp/impl/AMQPConnectionTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -197,19 +198,20 @@ public class AMQPConnectionTest {
 
     @Test
     public void testWaitToStopListening_Connected_CallsAwaitTerminationOnExecutor() throws IOException, TimeoutException, InterruptedException {
+        Duration wait = Duration.ofMillis(1338);
         AMQPConnection conn = defaultTestConnection();
         conn.connect(defaultTestConnectionProps());
         when(mockExecutor.awaitTermination(1338, TimeUnit.MILLISECONDS)).thenReturn(true);
-        Assert.assertTrue(conn.waitToStopListening(1338));
+        Assert.assertTrue(conn.waitToStopListening(wait));
         verify(mockExecutor).awaitTermination(1338, TimeUnit.MILLISECONDS);
         when(mockExecutor.awaitTermination(1338, TimeUnit.MILLISECONDS)).thenReturn(false);
-        Assert.assertFalse(conn.waitToStopListening(1338));
+        Assert.assertFalse(conn.waitToStopListening(wait));
         verify(mockExecutor, times(2)).awaitTermination(1338, TimeUnit.MILLISECONDS);
     }
 
     @Test
     public void testWaitToStopListening_NotConnected_ReturnsTrue() throws IOException, TimeoutException, InterruptedException {
-        Assert.assertTrue(defaultTestConnection().waitToStopListening(1338));
+        Assert.assertTrue(defaultTestConnection().waitToStopListening(Duration.ofMillis(1338)));
         verify(mockExecutor, never()).awaitTermination(1338, TimeUnit.MILLISECONDS);
     }
 }

--- a/src/test/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilderTest.java
+++ b/src/test/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilderTest.java
@@ -1,8 +1,10 @@
 package io.rtr.conduit.amqp.impl;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class AMQPSyncConsumerBuilderTest {
 
@@ -65,6 +67,50 @@ public class AMQPSyncConsumerBuilderTest {
         assertEquals("When threshold isn't set, default to ", 10, commonListenProperties.getThreshold());
         assertEquals("When poisonPrefix not set, default to ", "", commonListenProperties.getPoisonPrefix());
         assertEquals("When poisonQEnabled not set, default to ", true, commonListenProperties.isPoisonQueueEnabled());
+        amqpSyncConsumerBuilder.build();
+    }
+
+    @Test
+    public void testSettingCredsAndSharedConnectionThrows(){
+        AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
+                .exchange("exchange")
+                .queue("queue")
+                .username("bob")
+                .sharedConnection(mock(AMQPConnection.class));
+
+        Assert.assertThrows(IllegalArgumentException.class, amqpSyncConsumerBuilder::build);
+    }
+
+    @Test
+    public void testSettingVhostAndSharedConnectionThrows(){
+        AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
+                .exchange("exchange")
+                .queue("queue")
+                .virtualHost("something")
+                .sharedConnection(mock(AMQPConnection.class));
+
+        Assert.assertThrows(IllegalArgumentException.class, amqpSyncConsumerBuilder::build);
+    }
+
+    @Test
+    public void testSettingOnlySharedConnectionDoesNotThrow(){
+        AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
+                .exchange("exchange")
+                .queue("queue")
+                .sharedConnection(mock(AMQPConnection.class));
+
+        amqpSyncConsumerBuilder.build();
+    }
+
+    @Test
+    public void testSettingOnlyCredsAndVhostDoesNotThrow(){
+        AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
+                .exchange("exchange")
+                .queue("queue")
+                .username("bob")
+                .password("bob")
+                .virtualHost("bob");
+
         amqpSyncConsumerBuilder.build();
     }
 }


### PR DESCRIPTION
Allowing a connection to be shared between multiple consumers & publishers should save threading & TCP resources, as well as enabling services to start up quicker