### PR TITLE
DEVELOPERS-127: Fix Nexus Publishing For Multi-Module Project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,12 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
 
+      # This step will run the tests, so we skip running them again on release:perform
       - name: Prepare release
         run: mvn -B release:prepare
 
       - name: Perform release
-        run: mvn -B release:perform
+        run: mvn -B release:perform -DskipTests
 
       - name: A step failed
         if: ${{ failure() }}

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,6 @@
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>1.6.8</version>
                         <extensions>true</extensions>
-                        <inherited>false</inherited>
                         <configuration>
                             <serverId>sonatype-nexus-staging</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>


### PR DESCRIPTION
Follow on from https://github.com/RentTheRunway/conduit/pull/71

Expected artefacts from v1.29 were no uploaded due to the `inherited` flag on the nexus plugin being disabled. 

See https://maven.apache.org/guides/mini/guide-configuring-plugins.html#Using_the_inherited_Tag_In_Build_Plugins.

Removing the tag will revert to default behaviour, which is plugins are inhertited by submodules.

---

Also while here, found the tests are being run twice by the release process. Adding a -DskipTest to make sure we only run once (reduce risk of failure).