### PR TITLE
RS-1316 Add exclusive option to consumer builder

### DIFF
--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilder.java
@@ -51,7 +51,8 @@ public class AMQPAsyncConsumerBuilder extends AMQPConsumerBuilder<AMQPAsyncTrans
                 getDynamicQueueRoutingKey(),
                 isAutoCreateAndBind(),
                 getExchangeType(),
-                getRoutingKey());
+                getRoutingKey(),
+                getExclusive());
     }
 
     @Override

--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncListenProperties.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPAsyncListenProperties.java
@@ -5,8 +5,8 @@ import io.rtr.conduit.amqp.AMQPAsyncConsumerCallback;
 public class AMQPAsyncListenProperties extends AMQPCommonListenProperties {
     private AMQPAsyncConsumerCallback callback;
 
-    AMQPAsyncListenProperties(AMQPAsyncConsumerCallback callback, String exchange, String queue, boolean isAutoDeleteQueue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean autoCreateAndBind, String exchangeType, String routingKey) {
-        super(exchange, queue, isAutoDeleteQueue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey, autoCreateAndBind, exchangeType, routingKey);
+    AMQPAsyncListenProperties(AMQPAsyncConsumerCallback callback, String exchange, String queue, boolean isAutoDeleteQueue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean autoCreateAndBind, String exchangeType, String routingKey, boolean exclusive) {
+        super(exchange, queue, isAutoDeleteQueue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey, autoCreateAndBind, exchangeType, routingKey, exclusive);
         this.callback = callback;
     }
     public AMQPAsyncConsumerCallback getCallback() {

--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPCommonListenProperties.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPCommonListenProperties.java
@@ -16,9 +16,10 @@ public abstract class AMQPCommonListenProperties implements TransportListenPrope
     private String routingKey;
     private boolean autoCreateAndBind;
     private String exchangeType;
+    private boolean exclusive;
 
 
-    AMQPCommonListenProperties(String exchange, String queue, boolean isAutoDeleteQueue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean autoCreateAndBind, String exchangeType, String routingKey) {
+    AMQPCommonListenProperties(String exchange, String queue, boolean isAutoDeleteQueue, int threshold, int prefetchCount, boolean poisonQueueEnabled, boolean purgeOnConnect, boolean dynamicQueueCreation, String poisonPrefix, String dynamicQueueRoutingKey, boolean autoCreateAndBind, String exchangeType, String routingKey, boolean exclusive) {
         this.exchange = exchange;
         this.queue = queue;
         this.isAutoDeleteQueue = isAutoDeleteQueue;
@@ -32,6 +33,7 @@ public abstract class AMQPCommonListenProperties implements TransportListenPrope
         this.routingKey = routingKey;
         this.autoCreateAndBind = autoCreateAndBind;
         this.exchangeType = exchangeType;
+        this.exclusive = exclusive;
     }
 
     public String getExchange() {
@@ -85,4 +87,6 @@ public abstract class AMQPCommonListenProperties implements TransportListenPrope
     public boolean isAutoDeleteQueue() {
         return isAutoDeleteQueue;
     }
+
+    public boolean getExclusive() { return exclusive; }
 }

--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
@@ -34,6 +34,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     private String routingKey = "";
     private boolean autoCreateAndBind = false;
     private ExchangeType exchangeType = ExchangeType.DIRECT;
+    private boolean exclusive = false;
 
     protected AMQPConsumerBuilder() {
     }
@@ -154,6 +155,11 @@ public abstract class AMQPConsumerBuilder<T extends Transport
         return builder();
     }
 
+    public R exclusive(boolean exclusive) {
+        this.exclusive = exclusive;
+        return builder();
+    }
+
     public AMQPConnection getSharedConnection() {
         return sharedConnection;
     }
@@ -238,6 +244,8 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     protected boolean isPoisonQueueEnabled() {
         return poisonQueueEnabled;
     }
+
+    protected boolean getExclusive() { return exclusive; }
 
     @Override
     protected void validate() {

--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPListenProperties.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPListenProperties.java
@@ -11,8 +11,8 @@ import io.rtr.conduit.amqp.transport.TransportListenProperties;
 public class AMQPListenProperties extends AMQPCommonListenProperties implements TransportListenProperties {
     private AMQPConsumerCallback callback;
 
-    AMQPListenProperties(AMQPConsumerCallback callback, String exchange, String queue, boolean isAutoDeleteQueue, int threshold, boolean poisonQueueEnabled, boolean purgeOnConnect, int prefetchCount, String poisonPrefix, String dynamicQueueRoutingKey, boolean dynamicQueueCreation, String exchangeType, String routingKey, boolean autoCreateAndBind) {
-        super(exchange, queue, isAutoDeleteQueue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey, autoCreateAndBind, exchangeType, routingKey);
+    AMQPListenProperties(AMQPConsumerCallback callback, String exchange, String queue, boolean isAutoDeleteQueue, int threshold, boolean poisonQueueEnabled, boolean purgeOnConnect, int prefetchCount, String poisonPrefix, String dynamicQueueRoutingKey, boolean dynamicQueueCreation, String exchangeType, String routingKey, boolean autoCreateAndBind, boolean exclusive) {
+        super(exchange, queue, isAutoDeleteQueue, threshold, prefetchCount, poisonQueueEnabled, purgeOnConnect, dynamicQueueCreation, poisonPrefix, dynamicQueueRoutingKey, autoCreateAndBind, exchangeType, routingKey, exclusive);
         this.callback = callback;
     }
 

--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilder.java
@@ -51,7 +51,8 @@ public class AMQPSyncConsumerBuilder extends AMQPConsumerBuilder<AMQPTransport
                 isDynamicQueueCreation(),
                 getExchangeType(),
                 getRoutingKey(),
-                isAutoCreateAndBind()
+                isAutoCreateAndBind(),
+                getExclusive()
         );
     }
 

--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
@@ -139,6 +139,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
         AMQPCommonListenProperties commonListenProperties = getCommonListenProperties(properties);
         String queue = commonListenProperties.getQueue();
         String poisonPrefix = commonListenProperties.getPoisonPrefix();
+        boolean exclusive = commonListenProperties.getExclusive();
 
         if (commonListenProperties.isDynamicQueueCreation()) {
             queue = createDynamicQueue(commonListenProperties.getExchange(),
@@ -165,7 +166,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
                 commonListenProperties,
                 poisonPrefix);
         getChannel().basicQos(commonListenProperties.getPrefetchCount());
-        getChannel().basicConsume(queue, noAutoAck, consumer);
+        getChannel().basicConsume(queue, noAutoAck, "", false, exclusive, (Map)null, consumer);
     }
 
     protected String createDynamicQueue(String exchange,


### PR DESCRIPTION
Adding exclusive option to consumer builder to allow rescache to enforce only 1 pod at a time to consume from VIP inventory updates queue

[Ticket](https://renttherunway.jira.com/browse/RS-1316)