### PR TITLE
DO NOT MERGE - Adding get channel to consumer

### DIFF
--- a/conduit/src/main/java/io/rtr/conduit/amqp/consumer/Consumer.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/consumer/Consumer.java
@@ -1,5 +1,6 @@
 package io.rtr.conduit.amqp.consumer;
 
+import com.rabbitmq.client.Channel;
 import io.rtr.conduit.amqp.transport.Transport;
 import io.rtr.conduit.amqp.transport.TransportListenContext;
 
@@ -46,4 +47,6 @@ public class Consumer implements AutoCloseable {
     private Transport getTransport() {
         return transportContext.getTransport();
     }
+
+    public Channel getChannel() { return getTransport().getChannel(); }
 }

--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPTransport.java
@@ -76,7 +76,7 @@ public class AMQPTransport extends AbstractAMQPTransport {
     }
 
 
-    protected Channel getChannel() {
+    public Channel getChannel() {
         return channel;
     }
 

--- a/conduit/src/main/java/io/rtr/conduit/amqp/transport/Transport.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/transport/Transport.java
@@ -1,5 +1,7 @@
 package io.rtr.conduit.amqp.transport;
 
+import com.rabbitmq.client.Channel;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.TimeoutException;
@@ -48,6 +50,9 @@ public abstract class Transport {
             throws IOException, TimeoutException, InterruptedException {
         return transactionalPublishImpl(messageBundles, properties);
     }
+
+    // Gets the current channel
+    public abstract Channel getChannel();
 
     //! Implementation
 


### PR DESCRIPTION
Exposing channel to consumer to allow rescache to use the consumerCount(String queue) method to detect 0 consumers on exclusive queue and handle accordingly. 

[Ticket](https://renttherunway.jira.com/browse/RS-1107)