### PR TITLE
FILL-774-builder-network-recovery-interval-config

### DIFF
--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPConsumerBuilder.java
@@ -35,6 +35,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     private boolean autoCreateAndBind = false;
     private ExchangeType exchangeType = ExchangeType.DIRECT;
     private boolean exclusive = false;
+    private long networkRecoveryInterval = 5000L;
 
     protected AMQPConsumerBuilder() {
     }
@@ -98,6 +99,11 @@ public abstract class AMQPConsumerBuilder<T extends Transport
 
     public R automaticRecoveryEnabled(boolean automaticRecoveryEnabled) {
         this.automaticRecoveryEnabled = automaticRecoveryEnabled;
+        return builder();
+    }
+
+    public R networkRecoveryInterval(long networkRecoveryInterval) {
+        this.networkRecoveryInterval = networkRecoveryInterval;
         return builder();
     }
 
@@ -247,6 +253,11 @@ public abstract class AMQPConsumerBuilder<T extends Transport
         return poisonQueueEnabled;
     }
 
+    public long getNetworkRecoveryInterval() {
+        return networkRecoveryInterval;
+    }
+
+
     @Override
     protected void validate() {
         assertNotNull(exchange, "exchange");
@@ -277,7 +288,7 @@ public abstract class AMQPConsumerBuilder<T extends Transport
     @Override
     protected AMQPConnectionProperties buildConnectionProperties() {
         return new AMQPConnectionProperties(username, password, virtualHost, connectionTimeout,
-                heartbeatInterval, automaticRecoveryEnabled);
+                heartbeatInterval, automaticRecoveryEnabled, networkRecoveryInterval);
     }
 
     public enum ExchangeType {

--- a/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilderTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilderTest.java
@@ -136,4 +136,29 @@ public class AMQPSyncConsumerBuilderTest {
 
         amqpSyncConsumerBuilder.build();
     }
+
+    @Test
+    public void testDefaultConnectionProperties() {
+        AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
+                .exchange("exchange")
+                .queue("queue")
+                .username("bob")
+                .password("bob");
+
+        AMQPConnectionProperties connectionProperties = amqpSyncConsumerBuilder.buildConnectionProperties();
+        assertEquals(5000, connectionProperties.getNetworkRecoveryInterval(), "When Network Recovery Interval not set, default to ");
+    }
+
+    @Test
+    public void testOverrideConnectionProperties() {
+        AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
+                .exchange("exchange")
+                .queue("queue")
+                .username("bob")
+                .password("bob")
+                .networkRecoveryInterval(10000L);
+
+        AMQPConnectionProperties connectionProperties = amqpSyncConsumerBuilder.buildConnectionProperties();
+        assertEquals(10000, connectionProperties.getNetworkRecoveryInterval(), "When Network Recovery Interval not set, default to ");
+    }
 }

--- a/conduit/src/test/java/io/rtr/conduit/integration/ShutdownHandlerIntegrationTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/integration/ShutdownHandlerIntegrationTest.java
@@ -32,7 +32,7 @@ public class ShutdownHandlerIntegrationTest {
         .withExposedPorts(5672)
         .withNetwork(COMMON_NETWORK);
     @Container
-    private static final ToxiproxyContainer TOXI_PROXY = new ToxiproxyContainer("shopify/toxiproxy:2.1.0")
+    private static final ToxiproxyContainer TOXI_PROXY = new ToxiproxyContainer("shopify/toxiproxy:2.1.4")
         .withNetwork(COMMON_NETWORK)
         .withNetworkAliases(TOXIPROXY_NETWORK_ALIAS);
 


### PR DESCRIPTION
[FILL-774 ](https://renttherunway.jira.com/browse/FILL-774)

Related to PR https://github.com/RentTheRunway/conduit/pull/109

Added Network Recovery Interval config to consumer builder, so that any client using builder can set it to override easily. default to 5sec.
Rabbit api reference - https://www.rabbitmq.com/api-guide.html

