### PR TITLE
Use jar-no-fork for the source plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
This goal is intended for use during the default lifecycle, whereas `jar` is standalone.