### PR TITLE
[SR-4142] Update actions to new versions that run on node16

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -21,32 +21,32 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         if: github.actor != 'dependabot[bot]'
 
       # See: https://hugo.alliau.me/2021/05/04/migration-to-github-native-dependabot-solutions-for-auto-merge-and-action-secrets/#share-your-secrets-with-dependabot
       - name: Checkout Repository [Dependabot]
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         if: github.actor == 'dependabot[bot]'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 8
           distribution: temurin
           check-latest: false
 
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v4
+        uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.8.2
 
       # actions/setup-java does not support multiple servers at this time
       # https://github.com/actions/setup-java/issues/85
       - name: Setup Nexus authentication and GPG passphrase
-        uses: whelk-io/maven-settings-xml-action@v20
+        uses: whelk-io/maven-settings-xml-action@v21
         with:
           servers: |
             [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Java and Maven
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 1.8
 
@@ -55,7 +55,7 @@ jobs:
           }]'
 
       - name: Setup Github SSH key
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@v0.6.0
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
 

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -6,7 +6,7 @@ jobs:
     name: woke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # For more details, see https://github.com/marketplace/actions/run-woke
       - uses: get-woke/woke-action@v0


### PR DESCRIPTION
This is an autogenerated PR to patch actions org-wide with newer versions that run on node16. In preparation for June 14th https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/