### PR TITLE
CE-1925: Update AMQPPublishProperties class to enable setting of timeout and confirmEnabled properties 

### DIFF
--- a/conduit/pom.xml
+++ b/conduit/pom.xml
@@ -11,6 +11,7 @@
 
     <properties>
         <junit-bom.version>5.8.2</junit-bom.version>
+        <assertj.version>3.25.3</assertj.version>
         <logback.version>1.2.11</logback.version>
         <slf4j.version>1.7.35</slf4j.version>
         <testcontainers-bom.version>1.16.3</testcontainers-bom.version>
@@ -63,6 +64,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>4.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- For verifying with RabbitMQ -->

--- a/conduit/src/main/java/io/rtr/conduit/amqp/AMQPMessageBundle.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/AMQPMessageBundle.java
@@ -4,14 +4,15 @@ import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Envelope;
 import io.rtr.conduit.amqp.transport.TransportMessageBundle;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class AMQPMessageBundle implements TransportMessageBundle {
-    private String consumerTag;
-    private Envelope envelope;
-    private AMQP.BasicProperties basicProperties;
-    private byte[] body;
+    private final String consumerTag;
+    private final Envelope envelope;
+    private final AMQP.BasicProperties basicProperties;
+    private final byte[] body;
 
     private static AMQP.BasicProperties initialProperties() {
         return initialProperties(null);
@@ -50,6 +51,13 @@ public class AMQPMessageBundle implements TransportMessageBundle {
         this(null, null, initialProperties(headers), message.getBytes());
     }
 
+    private AMQPMessageBundle(final Builder builder) {
+        this.consumerTag = builder.consumerTag;
+        this.envelope = builder.envelope;
+        this.basicProperties = builder.basicProperties;
+        this.body = builder.body;
+    }
+
     public String getConsumerTag() {
         return consumerTag;
     }
@@ -64,5 +72,66 @@ public class AMQPMessageBundle implements TransportMessageBundle {
 
     public byte[] getBody() {
         return body;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String consumerTag;
+        private Envelope envelope;
+        private AMQP.BasicProperties basicProperties;
+        private Map<String, Object> headers = new HashMap<>();
+        private byte[] body;
+
+        public Builder consumerTag(final String consumerTag) {
+            this.consumerTag = consumerTag;
+            return this;
+        }
+
+        public Builder envelope(final Envelope envelope) {
+            this.envelope = envelope;
+            return this;
+        }
+
+        public Builder basicProperties(final AMQP.BasicProperties basicProperties) {
+            this.basicProperties = basicProperties;
+            return this;
+        }
+
+        public Builder headers(final Map<String, Object> headers) {
+            if (headers != null) {
+                this.headers = new HashMap<>(headers);
+            }
+            return this;
+        }
+
+        public Builder header(final String name, final Object value) {
+            if (value == null) {
+                this.headers.remove(name);
+            } else {
+                this.headers.put(name, value);
+            }
+            return this;
+        }
+
+        public Builder body(final byte[] body) {
+            this.body = body;
+            return this;
+        }
+
+        public Builder body(final String body) {
+            return body(body.getBytes());
+        }
+
+        public AMQPMessageBundle build() {
+            if (basicProperties == null) {
+                this.basicProperties = initialProperties(headers);
+            } else if (headers != null) {
+                throw new IllegalArgumentException("Both basicProperties and headers are set");
+            }
+            return new AMQPMessageBundle(this);
+        }
     }
 }

--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPPublishProperties.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPPublishProperties.java
@@ -3,20 +3,23 @@ package io.rtr.conduit.amqp.impl;
 import io.rtr.conduit.amqp.transport.TransportPublishProperties;
 
 public class AMQPPublishProperties implements TransportPublishProperties {
-    private String exchange;
-    private String routingKey;
-    private long timeout;
-    private boolean confirmEnabled;
-
-    AMQPPublishProperties(String exchange, String routingKey, long timeout, boolean confirmEnabled) {
-        this.exchange = exchange;
-        this.routingKey = routingKey;
-        this.timeout = timeout;
-        this.confirmEnabled = confirmEnabled;
-    }
+    private final String exchange;
+    private final String routingKey;
+    private final long timeout;
+    private final boolean confirmEnabled;
 
     public AMQPPublishProperties(String exchange, String routingKey) {
-        this(exchange, routingKey, 100, false);
+        this.exchange = exchange;
+        this.routingKey = routingKey;
+        this.timeout = 100;
+        this.confirmEnabled = false;
+    }
+
+    private AMQPPublishProperties(final Builder builder) {
+        this.exchange = builder.exchange;
+        this.routingKey = builder.routingKey;
+        this.timeout = builder.timeout;
+        this.confirmEnabled = builder.confirmEnabled;
     }
 
     public String getExchange() {
@@ -33,5 +36,47 @@ public class AMQPPublishProperties implements TransportPublishProperties {
 
     public boolean isConfirmEnabled() {
         return confirmEnabled;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String exchange;
+        private String routingKey;
+        private long timeout;
+        private boolean confirmEnabled;
+
+        public Builder exchange(final String exchange) {
+            this.exchange = exchange;
+            return this;
+        }
+
+        public Builder routingKey(final String routingKey) {
+            this.routingKey = routingKey;
+            return this;
+        }
+
+        public Builder timeout(final long timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Builder confirmEnabled(final boolean confirmEnabled) {
+            this.confirmEnabled = confirmEnabled;
+            return this;
+        }
+
+        public Builder of(final AMQPPublishProperties base) {
+            return exchange(base.getExchange())
+                    .routingKey(base.getRoutingKey())
+                    .timeout(base.getTimeout())
+                    .confirmEnabled(base.isConfirmEnabled());
+        }
+
+        public AMQPPublishProperties build() {
+            return new AMQPPublishProperties(this);
+        }
     }
 }

--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPPublishProperties.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPPublishProperties.java
@@ -8,13 +8,6 @@ public class AMQPPublishProperties implements TransportPublishProperties {
     private final long timeout;
     private final boolean confirmEnabled;
 
-    public AMQPPublishProperties(String exchange, String routingKey) {
-        this.exchange = exchange;
-        this.routingKey = routingKey;
-        this.timeout = 100;
-        this.confirmEnabled = false;
-    }
-
     private AMQPPublishProperties(final Builder builder) {
         this.exchange = builder.exchange;
         this.routingKey = builder.routingKey;

--- a/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPPublisherBuilder.java
+++ b/conduit/src/main/java/io/rtr/conduit/amqp/impl/AMQPPublisherBuilder.java
@@ -127,7 +127,12 @@ public class AMQPPublisherBuilder extends PublisherBuilder<AMQPTransport
 
     @Override
     protected AMQPPublishProperties buildPublishProperties() {
-        return new AMQPPublishProperties(exchange, routingKey, publishTimeout, confirmEnabled);
+        return AMQPPublishProperties.builder()
+                .exchange(exchange)
+                .routingKey(routingKey)
+                .timeout(publishTimeout)
+                .confirmEnabled(confirmEnabled)
+                .build();
     }
 
     @Override

--- a/conduit/src/test/java/io/rtr/conduit/amqp/AMQPMessageBundleTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/amqp/AMQPMessageBundleTest.java
@@ -1,17 +1,22 @@
 package io.rtr.conduit.amqp;
 
+import com.rabbitmq.client.AMQP;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AMQPMessageBundleTest {
+class AMQPMessageBundleTest {
 
     @Test
-    public void testMessageBundleHeaders() {
+    void testMessageBundleHeaders() {
         // create message with default headers
         AMQPMessageBundle bundle1 = new AMQPMessageBundle("test");
         Map<String, Object> headers1 = new HashMap<>(bundle1.getBasicProperties().getHeaders());
@@ -28,7 +33,40 @@ public class AMQPMessageBundleTest {
         AMQPMessageBundle bundle2 = new AMQPMessageBundle("test", headers2);
         headers2 = new HashMap<>(bundle2.getBasicProperties().getHeaders());
 
-        assertTrue(headers2.size() > 0);
+        assertFalse(headers2.isEmpty());
         assertEquals(headers1, headers2);
+    }
+
+    @Test
+    void buildMessageWithHeaders_populatesPropertiesAndBody() {
+        final AMQPMessageBundle messageBundle = AMQPMessageBundle.builder()
+                .header("foo", 1)
+                .header("foo", null)
+                .header("bar", "baz")
+                .header("foo2", 2)
+                .body("A message")
+                .build();
+
+        assertThat(messageBundle.getBasicProperties())
+                .isNotNull()
+                .extracting(AMQP.BasicProperties::getHeaders)
+                .satisfies(headers -> assertThat(headers)
+                        .containsEntry("bar", "baz")
+                        .containsEntry("foo2", 2)
+                        .doesNotContainKey("foo"));
+        assertThat(messageBundle.getBody())
+                .satisfies(bytes -> assertThat(new String(bytes))
+                        .isEqualTo("A message"));
+    }
+
+    @Test
+    void settingBothBasicPropertiesAndHeaders_throws() {
+        final AMQPMessageBundle.Builder builder = AMQPMessageBundle.builder()
+                .basicProperties(new AMQP.BasicProperties())
+                .headers(singletonMap("foo", 1));
+
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Both basicProperties and headers are set");
     }
 }

--- a/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class AMQPAsyncConsumerBuilderTest {
+class AMQPAsyncConsumerBuilderTest {
 
     @Test
-    public void testValidationDynamicWithNullRoutingKey() {
+    void testValidationDynamicWithNullRoutingKey() {
         assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
             .dynamicQueueCreation(true)
             .dynamicQueueRoutingKey(null)
@@ -22,7 +22,7 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
-    public void testValidationDynamicWithRoutingKeyAndQueue() {
+    void testValidationDynamicWithRoutingKeyAndQueue() {
         assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
             .dynamicQueueCreation(true)
             .queue("myq")
@@ -31,7 +31,7 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
-    public void testValidationExchangeRequired() {
+    void testValidationExchangeRequired() {
         assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
             .dynamicQueueCreation(true)
             .dynamicQueueRoutingKey("myRouter")
@@ -39,14 +39,14 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
-    public void testValidationQueueRequiredWhenNotDynamic() {
+    void testValidationQueueRequiredWhenNotDynamic() {
         assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
             .exchange("exchange")
             .build());
     }
 
     @Test
-    public void testValidationAutoCreateAndBind() {
+    void testValidationAutoCreateAndBind() {
         AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
             .autoCreateAndBind("exchange", DIRECT, "queue", "routingKey");
         AMQPCommonListenProperties commonListenProperties = amqpAsyncConsumerBuilder.buildListenProperties();
@@ -63,7 +63,7 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
-    public void testAutoCreateAndBindWithAutoDeleteQueue() {
+    void testAutoCreateAndBindWithAutoDeleteQueue() {
         AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
             .autoCreateAndBind("exchange", CONSISTENT_HASH, "queue", true, "routingKey");
         AMQPCommonListenProperties commonListenProperties = amqpAsyncConsumerBuilder.buildListenProperties();
@@ -80,7 +80,7 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
-    public void testValidationAutoCreateAndBindWithNullRoutingKey() {
+    void testValidationAutoCreateAndBindWithNullRoutingKey() {
         AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
             .autoCreateAndBind("exchange", DIRECT, "queue", null);
 
@@ -90,14 +90,14 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
-    public void testValidationAutoCreateAndBindWithNullQueue() {
+    void testValidationAutoCreateAndBindWithNullQueue() {
         assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
             .autoCreateAndBind("exchange", DIRECT, null, "routingKey")
             .build());
     }
 
     @Test
-    public void testValidationAutoCreateAndBindWithDynamic() {
+    void testValidationAutoCreateAndBindWithDynamic() {
         assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
             .dynamicQueueCreation(true)
             .autoCreateAndBind("exchange", DIRECT, "queue", "routingKey")
@@ -105,7 +105,7 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
-    public void testValidationAutoCreateAndBindWithPoisonFanout() {
+    void testValidationAutoCreateAndBindWithPoisonFanout() {
         assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
             .poisonQueueEnabled(true)
             .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.FANOUT, "queue", "routingKey")
@@ -113,7 +113,7 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
-    public void testDefaultDynamic() {
+    void testDefaultDynamic() {
         AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
             .exchange("exchange")
             .dynamicQueueCreation(true)
@@ -128,7 +128,7 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
-    public void testDefaultExplicit() {
+    void testDefaultExplicit() {
         AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
             .exchange("exchange")
             .queue("queue");
@@ -142,7 +142,7 @@ public class AMQPAsyncConsumerBuilderTest {
     }
 
     @Test
-    public void testSettingCredsAndSharedConnectionThrows() {
+    void testSettingCredsAndSharedConnectionThrows() {
         AMQPAsyncConsumerBuilder amqpAsyncConsumerBuilder = AMQPAsyncConsumerBuilder.builder()
             .exchange("exchange")
             .queue("queue")

--- a/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncConsumerBuilderTest.java
@@ -15,34 +15,34 @@ class AMQPAsyncConsumerBuilderTest {
 
     @Test
     void testValidationDynamicWithNullRoutingKey() {
-        assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
-            .dynamicQueueCreation(true)
-            .dynamicQueueRoutingKey(null)
-            .build());
+        final AMQPAsyncConsumerBuilder builder = AMQPAsyncConsumerBuilder.builder()
+                .dynamicQueueCreation(true)
+                .dynamicQueueRoutingKey(null);
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     void testValidationDynamicWithRoutingKeyAndQueue() {
-        assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
-            .dynamicQueueCreation(true)
-            .queue("myq")
-            .dynamicQueueRoutingKey("myRouter")
-            .build());
+        final AMQPAsyncConsumerBuilder builder = AMQPAsyncConsumerBuilder.builder()
+                .dynamicQueueCreation(true)
+                .queue("myq")
+                .dynamicQueueRoutingKey("myRouter");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     void testValidationExchangeRequired() {
-        assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
-            .dynamicQueueCreation(true)
-            .dynamicQueueRoutingKey("myRouter")
-            .build());
+        final AMQPAsyncConsumerBuilder builder = AMQPAsyncConsumerBuilder.builder()
+                .dynamicQueueCreation(true)
+                .dynamicQueueRoutingKey("myRouter");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     void testValidationQueueRequiredWhenNotDynamic() {
-        assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
-            .exchange("exchange")
-            .build());
+        final AMQPAsyncConsumerBuilder builder = AMQPAsyncConsumerBuilder.builder()
+                .exchange("exchange");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
@@ -91,25 +91,25 @@ class AMQPAsyncConsumerBuilderTest {
 
     @Test
     void testValidationAutoCreateAndBindWithNullQueue() {
-        assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
-            .autoCreateAndBind("exchange", DIRECT, null, "routingKey")
-            .build());
+        final AMQPAsyncConsumerBuilder builder = AMQPAsyncConsumerBuilder.builder()
+                .autoCreateAndBind("exchange", DIRECT, null, "routingKey");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     void testValidationAutoCreateAndBindWithDynamic() {
-        assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
-            .dynamicQueueCreation(true)
-            .autoCreateAndBind("exchange", DIRECT, "queue", "routingKey")
-            .build());
+        final AMQPAsyncConsumerBuilder builder = AMQPAsyncConsumerBuilder.builder()
+                .dynamicQueueCreation(true)
+                .autoCreateAndBind("exchange", DIRECT, "queue", "routingKey");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     void testValidationAutoCreateAndBindWithPoisonFanout() {
-        assertThrows(IllegalArgumentException.class, () -> AMQPAsyncConsumerBuilder.builder()
-            .poisonQueueEnabled(true)
-            .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.FANOUT, "queue", "routingKey")
-            .build());
+        final AMQPAsyncConsumerBuilder builder = AMQPAsyncConsumerBuilder.builder()
+                .poisonQueueEnabled(true)
+                .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.FANOUT, "queue", "routingKey");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test

--- a/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncQueueConsumerTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPAsyncQueueConsumerTest.java
@@ -30,10 +30,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 
-public class AMQPAsyncQueueConsumerTest {
+class AMQPAsyncQueueConsumerTest {
 
     @Test
-    public void testRespondMultipleAcknowledgeAll() throws Exception {
+    void testRespondMultipleAcknowledgeAll() throws Exception {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
 
         // this callback will acknowledge the 2nd message
@@ -74,7 +74,7 @@ public class AMQPAsyncQueueConsumerTest {
     }
 
     @Test
-    public void testRespondSingleAcknowledge() throws Exception {
+    void testRespondSingleAcknowledge() throws Exception {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
 
         // this callback will acknowledge the 2nd message
@@ -116,7 +116,7 @@ public class AMQPAsyncQueueConsumerTest {
 
 
     @Test
-    public void testRespondMultipleRejectAndDiscardAll() throws Exception {
+    void testRespondMultipleRejectAndDiscardAll() throws Exception {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
 
         // this callback will discard the 2nd message
@@ -161,7 +161,7 @@ public class AMQPAsyncQueueConsumerTest {
     }
 
     @Test
-    public void testRespondMultipleRejectAndDiscardAllWithoutPoisonQueue() throws Exception {
+    void testRespondMultipleRejectAndDiscardAllWithoutPoisonQueue() throws Exception {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
 
         // this callback will discard the 2nd message
@@ -208,7 +208,7 @@ public class AMQPAsyncQueueConsumerTest {
     }
 
     @Test
-    public void testRespondSingleRejectAndDiscard() throws Exception {
+    void testRespondSingleRejectAndDiscard() throws Exception {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
 
         // this callback will discard only the 2nd message
@@ -262,7 +262,7 @@ public class AMQPAsyncQueueConsumerTest {
 
 
     @Test
-    public void testRespondSingleRejectAndDiscardWithoutPoisonQueue() throws Exception {
+    void testRespondSingleRejectAndDiscardWithoutPoisonQueue() throws Exception {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
 
         // this callback will discard only the 2nd message
@@ -317,7 +317,7 @@ public class AMQPAsyncQueueConsumerTest {
     }
 
     @Test
-    public void testRespondMultipleRejectAndRequeueAll() throws Exception {
+    void testRespondMultipleRejectAndRequeueAll() throws Exception {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
 
         // this callback will requeue every 2nd message
@@ -391,7 +391,7 @@ public class AMQPAsyncQueueConsumerTest {
     }
 
     @Test
-    public void testRespondSingleRejectAndRequeue() throws Exception {
+    void testRespondSingleRejectAndRequeue() throws Exception {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
 
         // this callback will requeue every 2nd message
@@ -465,7 +465,7 @@ public class AMQPAsyncQueueConsumerTest {
     }
 
     @Test
-    public void testHandleDeliveryMixedResponses() throws Exception {
+    void testHandleDeliveryMixedResponses() throws Exception {
         AMQPAsyncConsumerCallback callback = new AMQPAsyncConsumerCallback() {
 
             private int count = 0;
@@ -538,7 +538,7 @@ public class AMQPAsyncQueueConsumerTest {
     }
 
     @Test
-    public void testHandleDeliveryMixedRetryValues() throws Exception {
+    void testHandleDeliveryMixedRetryValues() throws Exception {
         AMQPAsyncConsumerCallback callback = new AMQPAsyncConsumerCallback() {
 
             private int count = 0;
@@ -611,7 +611,7 @@ public class AMQPAsyncQueueConsumerTest {
     }
 
     @Test
-    public void testShutdownHandlerInvocation() {
+    void testShutdownHandlerInvocation() {
         AMQPAsyncConsumerCallback callback = mock(AMQPAsyncConsumerCallback.class);
         Channel channel = mock(Channel.class);
         AMQPAsyncQueueConsumer consumer = spy(new AMQPAsyncQueueConsumer(channel, callback, 1, "", true));

--- a/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPConnectionPropertiesTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPConnectionPropertiesTest.java
@@ -6,9 +6,9 @@ import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AMQPConnectionPropertiesTest {
+class AMQPConnectionPropertiesTest {
     @Test
-    public void testValidateBuilder() {
+    void testValidateBuilder() {
         AMQPConnectionProperties properties = AMQPConnectionProperties.builder()
                 .username("Anna")
                 .password("Anna's password")
@@ -28,7 +28,7 @@ public class AMQPConnectionPropertiesTest {
     }
 
     @Test
-    public void testDefaultNetworkRecoveryInterval() {
+    void testDefaultNetworkRecoveryInterval() {
         AMQPConnectionProperties properties = AMQPConnectionProperties.builder()
                 .username("Anna")
                 .password("Anna's password")

--- a/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPConnectionTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPConnectionTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class AMQPConnectionTest {
+class AMQPConnectionTest {
     private final static int CONNECTION_TIMEOUT = 1337;
     private final static int PORT = 42;
 
@@ -63,7 +63,7 @@ public class AMQPConnectionTest {
     }
 
     @BeforeEach
-    public void before() throws IOException, TimeoutException {
+    void before() throws IOException, TimeoutException {
         mockFactory = mock(ConnectionFactory.class);
         mockExecutor = mock(TransportExecutor.class);
         mockMetrics = mock(MetricsCollector.class);
@@ -79,7 +79,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testConstructor_NoSll_SetsHostPortAndMetrics() {
+    void testConstructor_NoSll_SetsHostPortAndMetrics() {
         new AMQPConnection(mockFactory, ()->mockExecutor, false, "RABBIT HOST", PORT, mockMetrics);
         verify(mockFactory).setHost("RABBIT HOST");
         verify(mockFactory).setPort(PORT);
@@ -89,7 +89,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testConstructor_Sll_SetsSocketFactory() {
+    void testConstructor_Sll_SetsSocketFactory() {
         new AMQPConnection(mockFactory, ()->mockExecutor, true, "RABBIT HOST", PORT, mockMetrics);
         verify(mockFactory).setHost("RABBIT HOST");
         verify(mockFactory).setPort(PORT);
@@ -99,13 +99,13 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testConstructor_MetricsNull_SetsNoMetrics() {
+    void testConstructor_MetricsNull_SetsNoMetrics() {
         new AMQPConnection(mockFactory, ()->mockExecutor, false, "RABBIT HOST", PORT, null);
         verify(mockFactory, never()).setMetricsCollector(any());
     }
 
     @Test
-    public void testConnect_NotConnected_TransfersPropsToFactoryAndConnects() throws IOException, TimeoutException {
+    void testConnect_NotConnected_TransfersPropsToFactoryAndConnects() throws IOException, TimeoutException {
         defaultTestConnection().connect(defaultTestConnectionProps());
 
         verify(mockFactory).setUsername("BOB");
@@ -120,7 +120,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testConnect_AlreadyConnected_DoesNothing() throws IOException, TimeoutException {
+    void testConnect_AlreadyConnected_DoesNothing() throws IOException, TimeoutException {
         AMQPConnection conn = defaultTestConnection();
         conn.connect(defaultTestConnectionProps());
         conn.connect(defaultTestConnectionProps());
@@ -129,7 +129,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testDisconnect_Connected_ClosesConnection() throws IOException, TimeoutException {
+    void testDisconnect_Connected_ClosesConnection() throws IOException, TimeoutException {
         AMQPConnection conn = defaultTestConnection();
         conn.connect(defaultTestConnectionProps());
         conn.disconnect();
@@ -139,14 +139,14 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testDisconnect_NotConnected_DoesNothing() throws IOException {
+    void testDisconnect_NotConnected_DoesNothing() throws IOException {
         defaultTestConnection().disconnect();
         verify(mockConnection, never()).close(anyInt());
         verify(mockExecutor, never()).shutdown();
     }
 
     @Test
-    public void testDisconnect_AlreadyDisconnected_DoesNothing() throws IOException, TimeoutException {
+    void testDisconnect_AlreadyDisconnected_DoesNothing() throws IOException, TimeoutException {
         AMQPConnection conn = defaultTestConnection();
         conn.connect(defaultTestConnectionProps());
         conn.disconnect();
@@ -157,7 +157,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testStopListening_Connected_OnlyShutsDownExecutor() throws IOException, TimeoutException {
+    void testStopListening_Connected_OnlyShutsDownExecutor() throws IOException, TimeoutException {
         AMQPConnection conn = defaultTestConnection();
         conn.connect(defaultTestConnectionProps());
         conn.stopListening();
@@ -167,13 +167,13 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testStopListening_NotConnected_DoesNothing() {
+    void testStopListening_NotConnected_DoesNothing() {
         defaultTestConnection().stopListening();
         verify(mockExecutor, never()).shutdown();
     }
 
     @Test
-    public void testStopListening_MultipleCalls_OnlyShutsDownExecutorOnce() throws IOException, TimeoutException {
+    void testStopListening_MultipleCalls_OnlyShutsDownExecutorOnce() throws IOException, TimeoutException {
         AMQPConnection conn = defaultTestConnection();
         conn.connect(defaultTestConnectionProps());
         conn.stopListening();
@@ -186,7 +186,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testAddRecoverListener() throws IOException, TimeoutException {
+    void testAddRecoverListener() throws IOException, TimeoutException {
         AMQPConnection conn = defaultTestConnection();
         conn.connect(defaultTestConnectionProps());
         conn.addRecoveryListener(recoveryListener);
@@ -194,7 +194,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testRemoveRecoverListener() throws IOException, TimeoutException {
+    void testRemoveRecoverListener() throws IOException, TimeoutException {
         AMQPConnection conn = defaultTestConnection();
         conn.connect(defaultTestConnectionProps());
         conn.removeRecoveryListener(recoveryListener);
@@ -202,7 +202,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testAddRecoverListener_NotConnected_DoesNothing() {
+    void testAddRecoverListener_NotConnected_DoesNothing() {
         AMQPConnection conn = defaultTestConnection();
         assertThrows(IllegalStateException.class, () -> {
             conn.addRecoveryListener(recoveryListener);
@@ -210,7 +210,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testRemoveRecoverListener_NotConnected_DoesNothing() {
+    void testRemoveRecoverListener_NotConnected_DoesNothing() {
         AMQPConnection conn = defaultTestConnection();
         assertThrows(IllegalStateException.class, () -> {
             conn.removeRecoveryListener(recoveryListener);
@@ -218,7 +218,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testCreateChannel_Connected_CreatesQos1Channel() throws IOException, TimeoutException {
+    void testCreateChannel_Connected_CreatesQos1Channel() throws IOException, TimeoutException {
         AMQPConnection conn = defaultTestConnection();
         conn.connect(defaultTestConnectionProps());
         Channel channel = conn.createChannel();
@@ -226,14 +226,14 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testCreateChannel_NotConnected_Throws() {
+    void testCreateChannel_NotConnected_Throws() {
         AMQPConnection conn = defaultTestConnection();
 
         assertThrows(IllegalStateException.class, conn::createChannel);
     }
 
     @Test
-    public void testIsConnected_Connected_ReturnsTrue() throws IOException, TimeoutException {
+    void testIsConnected_Connected_ReturnsTrue() throws IOException, TimeoutException {
         AMQPConnection conn = defaultTestConnection();
         assertFalse(conn.isConnected());
         conn.connect(defaultTestConnectionProps());
@@ -245,7 +245,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testWaitToStopListening_Connected_CallsAwaitTerminationOnExecutor() throws IOException, TimeoutException, InterruptedException {
+    void testWaitToStopListening_Connected_CallsAwaitTerminationOnExecutor() throws IOException, TimeoutException, InterruptedException {
         Duration wait = Duration.ofMillis(1338);
         AMQPConnection conn = defaultTestConnection();
         conn.connect(defaultTestConnectionProps());
@@ -258,7 +258,7 @@ public class AMQPConnectionTest {
     }
 
     @Test
-    public void testWaitToStopListening_NotConnected_ReturnsTrue() throws InterruptedException {
+    void testWaitToStopListening_NotConnected_ReturnsTrue() throws InterruptedException {
         assertTrue(defaultTestConnection().waitToStopListening(Duration.ofMillis(1338)));
         verify(mockExecutor, never()).awaitTermination(1338, TimeUnit.MILLISECONDS);
     }

--- a/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPPublishPropertiesTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPPublishPropertiesTest.java
@@ -1,0 +1,32 @@
+package io.rtr.conduit.amqp.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AMQPPublishPropertiesTest {
+
+    @Test
+    void builderPopulatesAllFields() {
+        assertThat(populatedProperties())
+                .hasNoNullFieldsOrProperties();
+    }
+
+    @Test
+    void builderCopyEqualityCheck() {
+        final AMQPPublishProperties properties = populatedProperties();
+
+        assertThat(AMQPPublishProperties.builder().of(properties).build())
+                .usingRecursiveComparison()
+                .isEqualTo(properties);
+    }
+
+    private static AMQPPublishProperties populatedProperties() {
+        return AMQPPublishProperties.builder()
+                .exchange("an.exchange")
+                .routingKey("routing.key")
+                .timeout(321)
+                .confirmEnabled(true)
+                .build();
+    }
+}

--- a/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPQueueConsumerTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPQueueConsumerTest.java
@@ -25,9 +25,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class AMQPQueueConsumerTest {
+class AMQPQueueConsumerTest {
     @Test
-    public void testHandleDeliveryAcknowledge() {
+    void testHandleDeliveryAcknowledge() {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
 
         AMQPConsumerCallback callback = new AMQPConsumerCallback() {
@@ -59,7 +59,7 @@ public class AMQPQueueConsumerTest {
     }
 
     @Test
-    public void testHandleDeliveryRejectAndDiscard() throws Exception {
+    void testHandleDeliveryRejectAndDiscard() throws Exception {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
         final String actionReason = "Email was not sent since the user's email address was hard bounced by the Sailthru server";
 
@@ -98,7 +98,7 @@ public class AMQPQueueConsumerTest {
     }
 
     @Test
-    public void testHandleDeliveryRejectAndDiscardWithoutPoisonQueue() throws Exception {
+    void testHandleDeliveryRejectAndDiscardWithoutPoisonQueue() throws Exception {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
 
         AMQPConsumerCallback callback = new AMQPConsumerCallback() {
@@ -137,7 +137,7 @@ public class AMQPQueueConsumerTest {
     }
 
     @Test
-    public void testHandleDeliveryRejectAndRequeue() throws Exception {
+    void testHandleDeliveryRejectAndRequeue() throws Exception {
         final List<AMQPMessageBundle> messages = new ArrayList<>();
 
         AMQPConsumerCallback callback = new AMQPConsumerCallback() {

--- a/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilderTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPSyncConsumerBuilderTest.java
@@ -8,10 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class AMQPSyncConsumerBuilderTest {
+class AMQPSyncConsumerBuilderTest {
 
     @Test
-    public void testValidationDynamicWithNullRoutingKey() {
+    void testValidationDynamicWithNullRoutingKey() {
         assertThrows(IllegalArgumentException.class, () -> AMQPSyncConsumerBuilder.builder()
             .dynamicQueueCreation(true)
             .dynamicQueueRoutingKey(null)
@@ -19,7 +19,7 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testValidationDynamicWithRoutingKeyAndQueue() {
+    void testValidationDynamicWithRoutingKeyAndQueue() {
         assertThrows(IllegalArgumentException.class, () -> AMQPSyncConsumerBuilder.builder()
             .dynamicQueueCreation(true)
             .queue("myq")
@@ -28,7 +28,7 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testValidationExchangeRequired() {
+    void testValidationExchangeRequired() {
         assertThrows(IllegalArgumentException.class, () -> AMQPSyncConsumerBuilder.builder()
             .dynamicQueueCreation(true)
             .dynamicQueueRoutingKey("myRouter")
@@ -36,14 +36,14 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testValidationQueueRequiredWhenNotDynamic() {
+    void testValidationQueueRequiredWhenNotDynamic() {
         assertThrows(IllegalArgumentException.class, () -> AMQPSyncConsumerBuilder.builder()
             .exchange("exchange")
             .build());
     }
 
     @Test
-    public void testDefaultDynamic() {
+    void testDefaultDynamic() {
         AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
             .exchange("exchange")
             .dynamicQueueCreation(true)
@@ -59,7 +59,7 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testDefaultExplicit() {
+    void testDefaultExplicit() {
         AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
             .exchange("exchange")
             .queue("queue");
@@ -74,7 +74,7 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testAutoCreateAndBindDefault() {
+    void testAutoCreateAndBindDefault() {
         AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
             .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.CONSISTENT_HASH, "queue", "routingKey");
         AMQPCommonListenProperties commonListenProperties = amqpSyncConsumerBuilder.buildListenProperties();
@@ -84,7 +84,7 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testAutoCreateAndBindWithAutoDeleteQueue() {
+    void testAutoCreateAndBindWithAutoDeleteQueue() {
         AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
             .autoCreateAndBind("exchange", AMQPConsumerBuilder.ExchangeType.CONSISTENT_HASH, "queue", true, "routingKey");
         AMQPCommonListenProperties commonListenProperties = amqpSyncConsumerBuilder.buildListenProperties();
@@ -94,7 +94,7 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testSettingCredsAndSharedConnectionThrows() {
+    void testSettingCredsAndSharedConnectionThrows() {
         AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
             .exchange("exchange")
             .queue("queue")
@@ -105,7 +105,7 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testSettingVhostAndSharedConnectionThrows() {
+    void testSettingVhostAndSharedConnectionThrows() {
         AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
             .exchange("exchange")
             .queue("queue")
@@ -116,7 +116,7 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testSettingOnlySharedConnectionDoesNotThrow() {
+    void testSettingOnlySharedConnectionDoesNotThrow() {
         AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
             .exchange("exchange")
             .queue("queue")
@@ -126,7 +126,7 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testSettingOnlyCredsAndVhostDoesNotThrow() {
+    void testSettingOnlyCredsAndVhostDoesNotThrow() {
         AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
             .exchange("exchange")
             .queue("queue")
@@ -138,7 +138,7 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testDefaultConnectionProperties() {
+    void testDefaultConnectionProperties() {
         AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
                 .exchange("exchange")
                 .queue("queue")
@@ -150,7 +150,7 @@ public class AMQPSyncConsumerBuilderTest {
     }
 
     @Test
-    public void testOverrideConnectionProperties() {
+    void testOverrideConnectionProperties() {
         AMQPSyncConsumerBuilder amqpSyncConsumerBuilder = AMQPSyncConsumerBuilder.builder()
                 .exchange("exchange")
                 .queue("queue")

--- a/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPTransportTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/amqp/impl/AMQPTransportTest.java
@@ -8,6 +8,7 @@ import com.rabbitmq.client.impl.AMQImpl;
 import io.rtr.conduit.amqp.AMQPConsumerCallback;
 import io.rtr.conduit.amqp.AMQPMessageBundle;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -31,7 +32,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class AMQPTransportTest {
+class AMQPTransportTest {
     Channel channel;
     AMQPTransport amqpTransport;
     AMQPPublishProperties properties;
@@ -66,7 +67,7 @@ public class AMQPTransportTest {
     }
 
     @BeforeEach
-    public void before() throws IOException {
+    void before() throws IOException {
         amqpTransport = spy(new AMQPTransport(false, "host", 1234, null));
         channel = mock(Channel.class);
 
@@ -83,7 +84,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testConfirmModeDisabled() throws Exception {
+    void testConfirmModeDisabled() throws Exception {
         when(properties.isConfirmEnabled()).thenReturn(false);
 
         amqpTransport.publishImpl(messageBundle, properties);
@@ -93,7 +94,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testConfirmModeEnabled() throws Exception {
+    void testConfirmModeEnabled() throws Exception {
         long timeout = 9876;
         when(properties.getTimeout()).thenReturn(timeout);
         when(properties.isConfirmEnabled()).thenReturn(true);
@@ -107,7 +108,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testListenImplDynamicQueues() throws IOException {
+    void testListenImplDynamicQueues() throws IOException {
 
         amqpTransport.setChannel(channel);
 
@@ -123,7 +124,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testListenImplDynamicQueuesExclusive() throws IOException {
+    void testListenImplDynamicQueuesExclusive() throws IOException {
 
         amqpTransport.setChannel(channel);
 
@@ -139,7 +140,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testListenImplDynamicQueuesPurgeOnConnect() throws IOException {
+    void testListenImplDynamicQueuesPurgeOnConnect() throws IOException {
         AMQPCommonListenProperties commonListenProperties = dynamicQueueListenProperties(true, true, false)
             .buildListenProperties();
 
@@ -153,7 +154,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testListenImplDynamicQueues_ThrowsOnBind_StillSetsUpShutdownListener() throws IOException {
+    void testListenImplDynamicQueues_ThrowsOnBind_StillSetsUpShutdownListener() throws IOException {
         when(channel.queueBind(anyString(), anyString(), anyString(), anyMap())).thenThrow(new RuntimeException());
 
         AMQPCommonListenProperties commonListenProperties = dynamicQueueListenProperties(false, false, false)
@@ -164,7 +165,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testListenImplDynamicQueues_ThrowsOnDeclare_StillSetsUpShutdownListener() throws IOException {
+    void testListenImplDynamicQueues_ThrowsOnDeclare_StillSetsUpShutdownListener() throws IOException {
         AMQPConsumerCallback consumerCallback = mock(AMQPConsumerCallback.class);
         AMQPCommonListenProperties commonListenProperties = AMQPSyncConsumerBuilder.builder()
             .callback(consumerCallback)
@@ -180,7 +181,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testListenImplBasicConfig() throws IOException {
+    void testListenImplBasicConfig() throws IOException {
         AMQPConsumerBuilder.ExchangeType exchangeType = AMQPConsumerBuilder.ExchangeType.DIRECT;
 
         AMQImpl.Queue.DeclareOk ok = mock(AMQImpl.Queue.DeclareOk.class);
@@ -213,7 +214,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testListenAutoDeleteQueue() throws IOException {
+    void testListenAutoDeleteQueue() throws IOException {
         AMQPConsumerBuilder.ExchangeType exchangeType = AMQPConsumerBuilder.ExchangeType.CONSISTENT_HASH;
 
         AMQImpl.Queue.DeclareOk ok = mock(AMQImpl.Queue.DeclareOk.class);
@@ -246,7 +247,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testClose_PrivateConnection_DisconnectsConnection() throws IOException {
+    void testClose_PrivateConnection_DisconnectsConnection() throws IOException {
         ConnectionFactory factory = mock(ConnectionFactory.class);
         int expectedTimeout = 5;
         when(factory.getConnectionTimeout()).thenReturn(expectedTimeout);
@@ -261,7 +262,7 @@ public class AMQPTransportTest {
 
 
     @Test
-    public void testClose_SharedConnection_DoesntDisconnectConnectionButClosesOpenChannel() throws IOException, TimeoutException {
+    void testClose_SharedConnection_DoesntDisconnectConnectionButClosesOpenChannel() throws IOException, TimeoutException {
         AMQPConnection connection = mock(AMQPConnection.class);
         when(connection.isConnected()).thenReturn(true);
 
@@ -275,7 +276,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testConnect_PrivateConnection_ConnectsAndCreatesChannel() throws IOException, TimeoutException {
+    void testConnect_PrivateConnection_ConnectsAndCreatesChannel() throws IOException, TimeoutException {
 
         amqpTransport = new AMQPTransport(false, "host", 1234, null);
         AMQPConnection connection = mock(AMQPConnection.class);
@@ -287,7 +288,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testConnect_PrivateConnectionAndClosedChannel_ConnectsAndCreatesChannel() throws IOException, TimeoutException {
+    void testConnect_PrivateConnectionAndClosedChannel_ConnectsAndCreatesChannel() throws IOException, TimeoutException {
         amqpTransport = new AMQPTransport(false, "host", 1234, null);
         AMQPConnection connection = mock(AMQPConnection.class);
         amqpTransport.setConnection(connection);
@@ -300,7 +301,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testConnect_SharedConnectionAndOpenChannel_DoesNothing() throws IOException, TimeoutException {
+    void testConnect_SharedConnectionAndOpenChannel_DoesNothing() throws IOException, TimeoutException {
         AMQPConnection connection = mock(AMQPConnection.class);
         when(connection.isConnected()).thenReturn(true);
 
@@ -314,7 +315,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testConnect_SharedConnection_JustCreatesChannel() throws IOException, TimeoutException {
+    void testConnect_SharedConnection_JustCreatesChannel() throws IOException, TimeoutException {
         AMQPConnection connection = mock(AMQPConnection.class);
 
         amqpTransport = new AMQPTransport(connection);
@@ -326,7 +327,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testClose_SharedConnectionAndClosedChannel_DoesNothing() throws IOException, TimeoutException {
+    void testClose_SharedConnectionAndClosedChannel_DoesNothing() throws IOException, TimeoutException {
         AMQPConnection connection = mock(AMQPConnection.class);
         when(connection.isConnected()).thenReturn(true);
 
@@ -340,7 +341,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testStop_PrivateConnection_ClosesChannelStopsConnectionListening() throws IOException, TimeoutException {
+    void testStop_PrivateConnection_ClosesChannelStopsConnectionListening() throws IOException, TimeoutException {
         AMQPConnection connection = mock(AMQPConnection.class);
         when(connection.isConnected()).thenReturn(true);
 
@@ -353,7 +354,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testStop_PrivateConnectionClosedChannel_ClosesChannelStopsConnectionListening() throws IOException, TimeoutException {
+    void testStop_PrivateConnectionClosedChannel_ClosesChannelStopsConnectionListening() throws IOException, TimeoutException {
         AMQPConnection connection = mock(AMQPConnection.class);
         when(connection.isConnected()).thenReturn(true);
 
@@ -366,7 +367,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testStop_SharedConnection_JustClosesOpenChannel() throws IOException, TimeoutException {
+    void testStop_SharedConnection_JustClosesOpenChannel() throws IOException, TimeoutException {
         AMQPConnection connection = mock(AMQPConnection.class);
         when(connection.isConnected()).thenReturn(true);
 
@@ -380,7 +381,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testStop_SharedConnectionAndClosedChannel_DoesNothing() throws IOException, TimeoutException {
+    void testStop_SharedConnectionAndClosedChannel_DoesNothing() throws IOException, TimeoutException {
         AMQPConnection connection = mock(AMQPConnection.class);
         when(connection.isConnected()).thenReturn(true);
 
@@ -394,7 +395,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testIsStopped_PrivateConnection_WaitsForConnectionToStopListening() throws InterruptedException {
+    void testIsStopped_PrivateConnection_WaitsForConnectionToStopListening() throws InterruptedException {
         Duration wait = Duration.ofMillis(666);
         AMQPConnection connection = mock(AMQPConnection.class);
         when(connection.isConnected()).thenReturn(true);
@@ -408,7 +409,7 @@ public class AMQPTransportTest {
     }
 
     @Test
-    public void testIsStopped_SharedConnection_JustChecksIfChannelIsOpen() throws InterruptedException {
+    void testIsStopped_SharedConnection_JustChecksIfChannelIsOpen() throws InterruptedException {
         AMQPConnection connection = mock(AMQPConnection.class);
         when(connection.isConnected()).thenReturn(true);
 
@@ -425,7 +426,8 @@ public class AMQPTransportTest {
         assertTrue(amqpTransport.isStopped(666));
     }
 
-    public static class DynamicQueueCleanupShutdownListenerTest {
+    @Nested
+    class DynamicQueueCleanupShutdownListenerTest {
         private static final String MOCK_DYNAMIC_QUEUE = "MOCK DYNAMIC QUEUE";
         private static final String MOCK_DYNAMIC_POISON_QUEUE = ".poison.MOCK DYNAMIC QUEUE";
 
@@ -437,7 +439,7 @@ public class AMQPTransportTest {
         AMQPTransport.DynamicQueueCleanupShutdownListener shutdownListener;
 
         @BeforeEach
-        public void setup() throws IOException {
+        void setup() throws IOException {
             AMQP.Queue.DeclareOk ok = mock(AMQP.Queue.DeclareOk.class);
             when(ok.getQueue()).thenReturn("MOCK DYNAMIC QUEUE");
 
@@ -504,7 +506,7 @@ public class AMQPTransportTest {
         }
 
         @Test
-        public void testShutdownCompleted_DynamicQueueCreatedWithoutPoisonQueue_AsynchronouslyDeletesDynamicQueue() throws IOException, TimeoutException {
+        void testShutdownCompleted_DynamicQueueCreatedWithoutPoisonQueue_AsynchronouslyDeletesDynamicQueue() throws IOException, TimeoutException {
             listen(false);
             shutdownListener.shutdownCompleted(null);
             shutdownListener.queueCleanupJob.join();
@@ -512,7 +514,7 @@ public class AMQPTransportTest {
         }
 
         @Test
-        public void testShutdownCompleted_DynamicQueueCreatedWithPoisonQueue_AsynchronouslyDeletesBothQueues() throws IOException, TimeoutException {
+        void testShutdownCompleted_DynamicQueueCreatedWithPoisonQueue_AsynchronouslyDeletesBothQueues() throws IOException, TimeoutException {
             listen(true);
             shutdownListener.shutdownCompleted(null);
             shutdownListener.queueCleanupJob.join();
@@ -520,7 +522,7 @@ public class AMQPTransportTest {
         }
 
         @Test
-        public void testShutdownCompleted_ErrorOnDynamicQueueDeclare_DeletesNoQueues() throws IOException {
+        void testShutdownCompleted_ErrorOnDynamicQueueDeclare_DeletesNoQueues() throws IOException {
             when(mainChannel.queueDeclare()).thenThrow(new RuntimeException());
             listen(true, RuntimeException.class);
             shutdownListener.shutdownCompleted(null);
@@ -529,7 +531,7 @@ public class AMQPTransportTest {
         }
 
         @Test
-        public void testShutdownCompleted_ErrorOnDynamicQueueBind_DeletesDynamicQueue() throws IOException, TimeoutException {
+        void testShutdownCompleted_ErrorOnDynamicQueueBind_DeletesDynamicQueue() throws IOException, TimeoutException {
             when(mainChannel.queueBind(eq(MOCK_DYNAMIC_QUEUE), anyString(), anyString())).thenThrow(new RuntimeException());
             listen(true, RuntimeException.class);
             shutdownListener.shutdownCompleted(null);
@@ -538,7 +540,7 @@ public class AMQPTransportTest {
         }
 
         @Test
-        public void testShutdownCompleted_ErrorOnPoisonQueueDeclare_DeletesDynamicQueue() throws IOException, TimeoutException {
+        void testShutdownCompleted_ErrorOnPoisonQueueDeclare_DeletesDynamicQueue() throws IOException, TimeoutException {
 
             when(mainChannel.queueDeclare(eq(MOCK_DYNAMIC_POISON_QUEUE), anyBoolean(), anyBoolean(), anyBoolean(), anyMap())).thenThrow(new RuntimeException());
             listen(true, RuntimeException.class);
@@ -548,7 +550,7 @@ public class AMQPTransportTest {
         }
 
         @Test
-        public void testShutdownCompleted_ErrorOnPoisonQueueBind_DeletesBothQueues() throws IOException, TimeoutException {
+        void testShutdownCompleted_ErrorOnPoisonQueueBind_DeletesBothQueues() throws IOException, TimeoutException {
             when(mainChannel.queueBind(eq(MOCK_DYNAMIC_POISON_QUEUE), anyString(), anyString())).thenThrow(new RuntimeException());
             listen(true, RuntimeException.class);
             shutdownListener.shutdownCompleted(null);
@@ -557,7 +559,7 @@ public class AMQPTransportTest {
         }
 
         @Test
-        public void testShutdownCompleted_ErrorOnDynamicQueueDelete_StillAttemptsToDeletePoisonQueue() throws IOException, TimeoutException {
+        void testShutdownCompleted_ErrorOnDynamicQueueDelete_StillAttemptsToDeletePoisonQueue() throws IOException, TimeoutException {
             when(cleanupChannel.queueDelete(anyString())).thenThrow(new RuntimeException());
             listen(true);
             shutdownListener.shutdownCompleted(null);
@@ -566,7 +568,7 @@ public class AMQPTransportTest {
         }
 
         @Test
-        public void testShutdownCompleted_ErrorOnPoisonQueueDelete_StillClosesChannels() throws IOException, TimeoutException {
+        void testShutdownCompleted_ErrorOnPoisonQueueDelete_StillClosesChannels() throws IOException, TimeoutException {
             when(poisonCleanupChannel.queueDelete(anyString())).thenThrow(new RuntimeException());
             listen(true);
             shutdownListener.shutdownCompleted(null);

--- a/conduit/src/test/java/io/rtr/conduit/integration/AMQPIntegrationTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/integration/AMQPIntegrationTest.java
@@ -21,12 +21,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 
 @Testcontainers
-public class AMQPIntegrationTest {
+class AMQPIntegrationTest {
     @Container
     private static final RabbitMQContainer RABBITMQ_CONTAINER = RabbitMQContainerFactory.createBrokerWithSingleExchangeAndQueue();
 
     @Test
-    public void testSslAmqpTransport() {
+    void testSslAmqpTransport() {
         AMQPMessageBundle message = new AMQPMessageBundle("a message");
         Publisher publisher = IntegrationTestHelpers.buildPublisher(RABBITMQ_CONTAINER);
         Consumer consumer = IntegrationTestHelpers.buildConsumer(RABBITMQ_CONTAINER, new LoggingAmqpCallbackHandler());
@@ -41,7 +41,7 @@ public class AMQPIntegrationTest {
     }
 
     @Test
-    public void testAmqpTransportWithSharedConnection() throws IOException {
+    void testAmqpTransportWithSharedConnection() throws IOException {
         AMQPMessageBundle message = new AMQPMessageBundle("a message");
         AMQPConnection connection = IntegrationTestHelpers.buildConnection(RABBITMQ_CONTAINER);
 
@@ -57,7 +57,7 @@ public class AMQPIntegrationTest {
     }
 
     @Test
-    public void testManualReconnectAfterManualClose() {
+    void testManualReconnectAfterManualClose() {
         AMQPConsumerCallback callback = mock(AMQPConsumerCallback.class);
         AMQPMessageBundle message = new AMQPMessageBundle("a message");
 
@@ -89,7 +89,7 @@ public class AMQPIntegrationTest {
     }
 
     @Test
-    public void testAmqpTransportWithAutoDeleteQueue() throws IOException {
+    void testAmqpTransportWithAutoDeleteQueue() throws IOException {
         AMQPConsumerCallback callback = mock(AMQPConsumerCallback.class);
         AMQPMessageBundle message = new AMQPMessageBundle("a message");
         AMQPConnection connection = IntegrationTestHelpers.buildConnection(RABBITMQ_CONTAINER);

--- a/conduit/src/test/java/io/rtr/conduit/integration/RabbitMQContainerFactory.java
+++ b/conduit/src/test/java/io/rtr/conduit/integration/RabbitMQContainerFactory.java
@@ -1,10 +1,5 @@
 package io.rtr.conduit.integration;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.HostConfig;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.RabbitMQContainer;

--- a/conduit/src/test/java/io/rtr/conduit/integration/ShutdownHandlerIntegrationTest.java
+++ b/conduit/src/test/java/io/rtr/conduit/integration/ShutdownHandlerIntegrationTest.java
@@ -20,10 +20,9 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @Testcontainers
-public class ShutdownHandlerIntegrationTest {
+class ShutdownHandlerIntegrationTest {
 
     private static final Network COMMON_NETWORK = Network.newNetwork();
     public static final String TOXIPROXY_NETWORK_ALIAS = "toxiproxy";
@@ -37,7 +36,7 @@ public class ShutdownHandlerIntegrationTest {
         .withNetworkAliases(TOXIPROXY_NETWORK_ALIAS);
 
     @Test
-    public void testReconnectAfterBrokerShutdown() throws IOException {
+    void testReconnectAfterBrokerShutdown() throws IOException {
         ToxiproxyContainer.ContainerProxy proxyInterface = TOXI_PROXY.getProxy(RABBIT_MQ_CONTAINER, 5672);
 
         RecordingAmqpCallbackHandler callbackHandler = new RecordingAmqpCallbackHandler();


### PR DESCRIPTION
Primary change is to update AMQPPublishProperties so that the timeout and confirmEnabled properties  can be set when publishing a message with override publish properties. The constructor setting these properties had been set as package-private.

Also 
- added a builder to AMQPMessageBundle
- removed unnecessary public modifiers from Jupiter (JUnit 5) unit tests
- resolved "Refactor the code of the lambda to have only one invocation possibly throwing a runtime exception" issues in some unit tests