### PR TITLE
INF-4681 Use new Vault secrets for Sonatype credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,24 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
-    env:
-      NEXUS_USER: ${{ secrets.OSS_NEXUS_USERNAME }}
-      NEXUS_PASS: ${{ secrets.OSS_NEXUS_PASSWORD }}
-
     steps:
       - name: Fail if not on valid branch
         if: github.ref != 'refs/heads/master'
         run: |
           echo "::error title=Invalid Branch::This workflow can only be run on specific branches"
           exit 1
+
+      - name: Import ansible-vault secret
+        uses: hashicorp/vault-action@v3
+        with:
+          url: ${{ secrets.VAULT_URL }}
+          method: approle
+          roleId: secrets-uploader
+          secretId: ${{ secrets.VAULT_UPLOADER_SECRET_ID }}
+          secrets: |
+            kv/data/mgmt/sonatype/usertoken username | NEXUS_USER ;
+            kv/data/mgmt/sonatype/usertoken password | NEXUS_PASS ;
+            kv/data/mgmt/sonatype/stagingprofile id | STAGING_PROFILE_ID
 
       - name: Check out repo
         uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,7 @@
                         <configuration>
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <stagingProfileId>5db1fdef03b4db</stagingProfileId>
+                            <stagingProfileId>${env.STAGING_PROFILE_ID}</stagingProfileId>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                             <detectBuildFailures>true</detectBuildFailures>
                             <keepStagingRepositoryOnFailure>false</keepStagingRepositoryOnFailure>


### PR DESCRIPTION
From the Maven Central folks:

>To configure a publisher’s plugin authentication you would need to update your plugin settings to use a user token instead of the Nexus UI username and password login.

I've added the new credentials to Vault, and this change is to retrieve them from from there during the release instead of adding them to the GitHub repo secrets.