### PR TITLE
INF-4681 Actually do use GitHub secrets instead of Vault directly

### DIFF
--- a/.github/workflows/actions-audit.yaml
+++ b/.github/workflows/actions-audit.yaml
@@ -6,7 +6,7 @@
 name: Github Actions Audit
 run-name: Audit ${{ github.event.repository.name }}
 
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   schedule:
     - cron: "30 21 * * 0,2,4"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,24 +14,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    env:
+      STAGING_PROFILE_ID: ${{ secrets.OSS_NEXUS_STAGING_PROFILE_ID }}
+      NEXUS_USER: ${{ secrets.OSS_NEXUS_USERNAME }}
+      NEXUS_PASS: ${{ secrets.OSS_NEXUS_PASSWORD }}
+
     steps:
       - name: Fail if not on valid branch
         if: github.ref != 'refs/heads/master'
         run: |
           echo "::error title=Invalid Branch::This workflow can only be run on specific branches"
           exit 1
-
-      - name: Import ansible-vault secret
-        uses: hashicorp/vault-action@v3
-        with:
-          url: ${{ secrets.VAULT_URL }}
-          method: approle
-          roleId: secrets-uploader
-          secretId: ${{ secrets.VAULT_UPLOADER_SECRET_ID }}
-          secrets: |
-            kv/data/mgmt/sonatype/usertoken username | NEXUS_USER ;
-            kv/data/mgmt/sonatype/usertoken password | NEXUS_PASS ;
-            kv/data/mgmt/sonatype/stagingprofile id | STAGING_PROFILE_ID
 
       - name: Check out repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Vault provides broader access than we want, so actually do just use GitHub secrets rather than Vault.  Followup to #158.